### PR TITLE
Gtk2HsStore.c: Remove invalid assertions.

### DIFF
--- a/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.c
+++ b/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.c
@@ -462,7 +462,6 @@ gtk2hs_store_iter_next (GtkTreeModel  *tree_model,
   WHEN_DEBUG(g_debug("calling gtk2hs_store_iter_next\t\t(%p, %p)\n", tree_model, iter));
   Gtk2HsStore *store = (Gtk2HsStore *) tree_model;
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), FALSE);
-  g_return_val_if_fail (iter->stamp == store->stamp, FALSE);
 
   gboolean result = gtk2hs_store_iter_next_impl(store->impl, iter);
   if (result) iter->stamp = store->stamp;
@@ -489,7 +488,6 @@ gtk2hs_store_iter_children (GtkTreeModel *tree_model,
   WHEN_DEBUG(g_debug("calling gtk2hs_store_iter_children\t(%p, %p, %p)\n", tree_model, iter, parent));
   Gtk2HsStore *store = (Gtk2HsStore *) tree_model;
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), FALSE);
-  g_return_val_if_fail (parent == NULL || parent->stamp == store->stamp, FALSE);
 
   gboolean result = gtk2hs_store_iter_children_impl(store->impl, iter, parent);
   if (result) iter->stamp = store->stamp;
@@ -604,7 +602,6 @@ gtk2hs_store_ref_node (GtkTreeModel *tree_model,
   WHEN_DEBUG(g_debug("calling gtk2hs_store_ref_node\t\t(%p, %p)\n", tree_model, iter));
   Gtk2HsStore *store = (Gtk2HsStore *) tree_model;
   g_return_if_fail (GTK2HS_IS_STORE (tree_model));
-  g_return_if_fail (iter->stamp == store->stamp);
 
   gtk2hs_store_ref_node_impl(store->impl, iter);
 }


### PR DESCRIPTION
See the thread I began on 2014-01-24 entitled "Error when adding nodes to a tree store in response to testExpandRow". The (invalid) assertion that was causing the immediate problem was removed and a new release was done. I installed that and more invalid assertions turned up that caused incorrect behavior similar, but not identical to the first issue (in this case, a node would expand, but not all its children would be visible; contracting and expanding again would work, because the grandchildren had gotten created as a result of the first expansion request and it is the creation of the grandchildren that creates the situation that triggers the bogus assertions; see the email thread). I found the documentation here on github that explains how to build and install from source with cabal-meta (thank you for the good documentation), deleted the bad assertions, and installed on my system. My application now behaves correctly.
