### PR TITLE
new function to get a pixbuf from a cairo surface

### DIFF
--- a/gtk/Graphics/UI/Gtk/Gdk/Pixbuf.chs
+++ b/gtk/Graphics/UI/Gtk/Gdk/Pixbuf.chs
@@ -353,6 +353,11 @@ pixbufNewFromFileAtScale filename width height preserveAspectRatio =
 #endif
 
 #if GTK_CHECK_VERSION(3,0,0)
+-- | Creates a new pixbuf from a cairo Surface.
+--
+-- Transfers image data from a cairo Surface and converts it to an RGB(A) representation inside a Pixbuf. This allows you to efficiently read individual pixels from cairo surfaces. For GdkWindows, use gdk_pixbuf_get_from_window() instead.
+-- 
+-- This function will create an RGB pixbuf with 8 bits per channel. The pixbuf will contain an alpha channel if the surface contains one.
 pixbufNewFromSurface :: Surface -> Int -> Int -> Int -> Int -> IO Pixbuf
 pixbufNewFromSurface surface srcX srcY width height =
   withSurface surface $ \ss -> wrapNewGObject mkPixbuf $


### PR DESCRIPTION
This patch allows calling gdk_pixbuf_get_from_surface() from gtk2hs. It's a gtk3 specific function, I'm putting it at 3.0.0+ but I'm not sure in which GTK version it was added.

I wrote this code half-guessing looking how you wrap similar functions. Maybe propageGError is needed, but I could not make it work.

I have a sample program and it works with it:
https://dl.dropboxusercontent.com/u/22600720/Main.hs

I think it's a really nice function...
