### PR TITLE
Reinstate layoutGetDrawWindow on Gtk+ 3.

### DIFF
--- a/gtk/Graphics/UI/Gtk/General/Structs.hsc
+++ b/gtk/Graphics/UI/Gtk/General/Structs.hsc
@@ -78,7 +78,6 @@ module Graphics.UI.Gtk.General.Structs (
 #endif
   widgetGetDrawWindow,
   widgetGetSize,
-  layoutGetDrawWindow,
   windowGetFrame,
 #endif
   styleGetForeground,
@@ -809,16 +808,6 @@ widgetGetSize da = withForeignPtr (unWidget.toWidget $ da) $ \wPtr -> do
     (height :: #{gtk2hs_type gint}) <- #{peek GtkAllocation, height}
 				(#{ptr GtkWidget, allocation} wPtr)
     return (fromIntegral width, fromIntegral height)
-
--- Layout related methods
-
--- | Retrieves the 'Drawable' part.
---
--- Removed in Gtk3.
-layoutGetDrawWindow :: Layout -> IO DrawWindow
-layoutGetDrawWindow lay = makeNewGObject mkDrawWindow $
-  withForeignPtr (unLayout lay) $
-  \lay' -> liftM castPtr $ #{peek GtkLayout, bin_window} lay'
 
 -- Window related methods
 

--- a/gtk/Graphics/UI/Gtk/Layout/Layout.chs
+++ b/gtk/Graphics/UI/Gtk/Layout/Layout.chs
@@ -63,9 +63,7 @@ module Graphics.UI.Gtk.Layout.Layout (
   layoutGetVAdjustment,
   layoutSetHAdjustment,
   layoutSetVAdjustment,
-#if GTK_MAJOR_VERSION < 3
   layoutGetDrawWindow,
-#endif
 
 -- * Attributes
   layoutHAdjustment,
@@ -91,9 +89,6 @@ import System.Glib.Properties
 import Graphics.UI.Gtk.Abstract.Object	(makeNewObject)
 {#import Graphics.UI.Gtk.Types#}
 {#import Graphics.UI.Gtk.Signals#}
-#if GTK_MAJOR_VERSION < 3
-import Graphics.UI.Gtk.General.Structs	(layoutGetDrawWindow)
-#endif
 import Graphics.UI.Gtk.Abstract.ContainerChildProperties
 
 {# context lib="gtk" prefix="gtk" #}
@@ -229,6 +224,13 @@ layoutSetVAdjustment self adjustment =
   {# call layout_set_vadjustment #}
     (toLayout self)
     adjustment
+
+-- | Retrieves the 'Drawable' part of the layout used for drawing operations.
+--
+layoutGetDrawWindow :: Layout -> IO DrawWindow
+layoutGetDrawWindow lay = makeNewGObject mkDrawWindow $
+  {# call layout_get_bin_window #}
+    (toLayout lay)
 
 --------------------
 -- Attributes


### PR DESCRIPTION
Previously this was not supported on Gtk+ 3, but you need it if you want to do any custom drawing in a `GtkLayout` (which my application does). I think it's just an oversight.

`gtk_layout_get_bin_window()` has existed since Gtk+ 2.14 so I feel pretty
comfortable using it on both the 2 and 3 builds (and deleting code), but I haven't tested the Gtk+ 2 build…
