### PR TITLE
GTK2 on Mac OS X/Quartz

### DIFF
--- a/gtk/Graphics/UI/Gtk/Gdk/DrawWindow.chs
+++ b/gtk/Graphics/UI/Gtk/Gdk/DrawWindow.chs
@@ -87,7 +87,7 @@ module Graphics.UI.Gtk.Gdk.DrawWindow (
   drawWindowGetPointerPos,
   drawWindowGetOrigin,
   drawWindowSetCursor,
-#if GTK_MAJOR_VERSION < 3
+#if GTK_MAJOR_VERSION < 3 && !defined(HAVE_QUARTZ_GTK)
   drawWindowForeignNew,
 #endif
   drawWindowGetDefaultRootWindow,
@@ -601,7 +601,7 @@ drawWindowSetCursor self cursor =
     self
     (fromMaybe (Cursor nullForeignPtr) cursor)
 
-#if GTK_MAJOR_VERSION < 3
+#if GTK_MAJOR_VERSION < 3 && !defined(HAVE_QUARTZ_GTK)
 -- | Get the handle to an exising window of the windowing system. The
 -- passed-in handle is a reference to a native window, that is, an Xlib XID
 -- for X windows and a HWND for Win32.

--- a/gtk/Graphics/UI/Gtk/General/Structs.hsc
+++ b/gtk/Graphics/UI/Gtk/General/Structs.hsc
@@ -595,7 +595,8 @@ toResponse i = ResponseUser $ fromIntegral i
 #if !defined(WIN32) || GTK_CHECK_VERSION(2,8,0)
 -- | The identifer of a window of the underlying windowing system.
 --
-#ifdef GDK_NATIVE_WINDOW_POINTER
+#if defined(GDK_NATIVE_WINDOW_POINTER) && !defined(HAVE_QUARTZ_GTK)
+--GDK Quartz also defined GDK_NATIVE_WINDOW_POINTER
 newtype NativeWindowId = NativeWindowId (Ptr ()) deriving (Eq, Show)
 unNativeWindowId :: NativeWindowId -> Ptr a
 unNativeWindowId (NativeWindowId id) = castPtr id
@@ -648,14 +649,14 @@ foreign import ccall unsafe "gdk_x11_window_get_xid"
 #endif
 
 -- | Get 'NativeWindowId' of 'Drawable'.
-#if GTK_MAJOR_VERSION < 3
+#if GTK_MAJOR_VERSION < 3 && !defined(HAVE_QUARTZ_GTK)
 drawableGetID :: DrawableClass d => d -> IO NativeWindowId
 #else
 drawableGetID :: DrawWindowClass d => d -> IO NativeWindowId
 #endif
 drawableGetID d =
   liftM toNativeWindowId $
-#if GTK_MAJOR_VERSION < 3
+#if GTK_MAJOR_VERSION < 3 && !defined(HAVE_QUARTZ_GTK)
   (\(Drawable drawable) ->
 #else
   (\(DrawWindow drawable) ->
@@ -673,7 +674,7 @@ drawableGetID d =
 #else
      return $ Just (DrawWindow drawable)
 #endif
-#if GTK_MAJOR_VERSION < 3
+#if GTK_MAJOR_VERSION < 3 && !defined(HAVE_QUARTZ_GTK)
   ) (toDrawable d)
 #else
   ) (toDrawWindow d)


### PR DESCRIPTION
Fix compilation of binding for GTK2 on Mac OS X with Quartz backend.
