### PR TITLE
Bump text upper version bounds

### DIFF
--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -47,7 +47,7 @@ Flag cairo_svg
 Library
         build-depends:  base >= 4 && < 5,
                         utf8-string >= 0.2 && < 0.4,
-                        text >= 0.11.0.6 && < 1.2,
+                        text >= 0.11.0.6 && < 1.3,
                         bytestring, mtl, array
         build-tools:    gtk2hsC2hs >= 0.13.11
         exposed-modules:  Graphics.Rendering.Cairo

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -35,7 +35,7 @@ Library
         build-depends:  base >= 4 && < 5,
                         utf8-string >= 0.2 && < 0.4,
                         bytestring >= 0.10 && < 0.11,
-                        text >= 0.11.0.6 && < 1.2,
+                        text >= 0.11.0.6 && < 1.3,
                         containers
         build-tools:    gtk2hsC2hs >= 0.13.11
         cpp-options:    -U__BLOCKS__

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -137,7 +137,7 @@ Flag fmode-binary
 Library
         build-depends:  base >= 4 && < 5,
                         array, containers, mtl, bytestring,
-                        text >= 0.11.0.6 && < 1.2,
+                        text >= 0.11.0.6 && < 1.3,
                         glib  >= 0.13.0.0 && < 0.14,
                         pango >= 0.13.0.0 && < 0.14,
                         cairo >= 0.13.0.0 && < 0.14

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -136,7 +136,7 @@ Flag fmode-binary
 Library
         build-depends:  base >= 4 && < 5,
                         array, containers, mtl, bytestring,
-                        text >= 0.11.0.6 && < 1.2,
+                        text >= 0.11.0.6 && < 1.3,
                         glib  >= 0.13.0.0 && < 0.14,
                         pango >= 0.13.0.0 && < 0.14,
                         cairo >= 0.13.0.0 && < 0.14

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -44,7 +44,7 @@ Library
                         process, directory, array, containers, pretty, mtl,
                         glib  >= 0.13.0.0 && < 0.14,
                         cairo >= 0.13.0.0 && < 0.14,
-                        text >= 0.11.0.6 && < 1.2
+                        text >= 0.11.0.6 && < 1.3
 
         if flag(new-exception)
           build-depends:  base >= 4


### PR DESCRIPTION
Allow use of the latest version of `text` (1.2.0.0).
