### PR TITLE
fixed CairoString-Text give non NULL-teminated string

### DIFF
--- a/cairo/Graphics/Rendering/Cairo/Internal/Utilities.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Utilities.chs
@@ -25,7 +25,8 @@ import System.IO.Unsafe (unsafePerformIO)
 import Codec.Binary.UTF8.String
 import Data.Char (ord, chr)
 import Data.Text (Text)
-import qualified Data.Text.Foreign as T (withCStringLen)
+import Data.ByteString (useAsCString)
+import qualified Data.Text.Encoding as T (encodeUtf8)
 
 {#context lib="cairo" prefix="cairo"#}
 
@@ -40,4 +41,4 @@ instance CairoString [Char] where
     withUTFString = withCAString . encodeString
 
 instance CairoString Text where
-    withUTFString s f = T.withCStringLen s (f . fst)
+    withUTFString s = useAsCString (T.encodeUtf8 s)


### PR DESCRIPTION
Hi!

Text instance of CairoString use `Data.Text.Foreign.withCStringLen`. A CString provided by it don't include NULL-terminal character. so, I was gotten run-time error.

```
Main.hs: user error (input string not valid UTF-8)
```

I fixed it.

Regards.
