### PR TITLE
Behaviour of shiftL/shiftR undefined with negative shifts

### DIFF
--- a/gtk/Graphics/UI/Gtk/ModelView/TreeStore.hs
+++ b/gtk/Graphics/UI/Gtk/ModelView/TreeStore.hs
@@ -246,7 +246,7 @@ getBitSlice (TreeIter _ a b c) off count =
 
   where getBitSliceWord :: Word -> Int -> Int -> Word
         getBitSliceWord word off count =
-          word `shiftR` off .&. (1 `shiftL` count - 1)
+          word `shift` (-off) .&. (1 `shiftL` count - 1)
 
 setBitSlice :: TreeIter -> Int -> Int -> Word -> TreeIter
 setBitSlice (TreeIter stamp a b c) off count value =
@@ -258,8 +258,8 @@ setBitSlice (TreeIter stamp a b c) off count value =
 
   where setBitSliceWord :: Word -> Int -> Int -> Word -> Word
         setBitSliceWord word off count value =
-          let mask = (1 `shiftL` count - 1) `shiftL` off
-           in (word .&. complement mask) .|. (value `shiftL` off)
+          let mask = (1 `shiftL` count - 1) `shift` off
+           in (word .&. complement mask) .|. (value `shift` off)
 
 
 --iterPrefixEqual :: TreeIter -> TreeIter -> Int -> Bool


### PR DESCRIPTION
This PR replaces calls to `shiftL` and `shiftR` with `shift`. Seems to be at least partly to blame for https://github.com/haskell/ThreadScope/issues/45.

However I'm also a bit suspicious about the bitwise operations on `Word` and `Int` since the size of these is not fixed and may be as small as 29 bits. Perhaps `Word32` would be preferable? Also, [this is a bit worrying!](https://github.com/gtk2hs/gtk2hs/blob/master/gtk/Graphics/UI/Gtk/ModelView/TreeStore.hs#L234)
