### PR TITLE
Use Word32 instead of Word for values that must be 32 bits long

### DIFF
--- a/gtk/Graphics/UI/Gtk/ModelView/TreeStore.hs
+++ b/gtk/Graphics/UI/Gtk/ModelView/TreeStore.hs
@@ -57,7 +57,7 @@ module Graphics.UI.Gtk.ModelView.TreeStore (
   ) where
 
 import Data.Bits
-import Data.Word (Word)
+import Data.Word (Word32)
 import Data.Maybe ( fromMaybe, isJust )
 import Data.Tree
 import Control.Monad ( when )
@@ -231,24 +231,22 @@ treeStoreDefaultDragDestIface = DragDestIface {
 -- low level bit-twiddling utility functions
 --
 
--- TODO: figure out how these things work when Word is 64 bits
-
-bitsNeeded :: Word -> Int
+bitsNeeded :: Word32 -> Int
 bitsNeeded n = bitsNeeded' 0 n
   where bitsNeeded' b 0 = b
         bitsNeeded' b n = bitsNeeded' (b+1) (n `shiftR` 1)
 
-getBitSlice :: TreeIter -> Int -> Int -> Word
+getBitSlice :: TreeIter -> Int -> Int -> Word32
 getBitSlice (TreeIter _ a b c) off count =
       getBitSliceWord a  off     count
   .|. getBitSliceWord b (off-32) count
   .|. getBitSliceWord c (off-64) count
 
-  where getBitSliceWord :: Word -> Int -> Int -> Word
+  where getBitSliceWord :: Word32 -> Int -> Int -> Word32
         getBitSliceWord word off count =
           word `shiftR` off .&. (1 `shiftL` count - 1)
 
-setBitSlice :: TreeIter -> Int -> Int -> Word -> TreeIter
+setBitSlice :: TreeIter -> Int -> Int -> Word32 -> TreeIter
 setBitSlice (TreeIter stamp a b c) off count value =
   assert (value < 1 `shiftL` count) $
   TreeIter stamp
@@ -256,7 +254,7 @@ setBitSlice (TreeIter stamp a b c) off count value =
            (setBitSliceWord b (off-32) count value)
            (setBitSliceWord c (off-64) count value)
 
-  where setBitSliceWord :: Word -> Int -> Int -> Word -> Word
+  where setBitSliceWord :: Word32 -> Int -> Int -> Word32 -> Word32
         setBitSliceWord word off count value =
           let mask = (1 `shiftL` count - 1) `shiftL` off
            in (word .&. complement mask) .|. (value `shiftL` off)
@@ -308,7 +306,7 @@ fromPath = fP 0 invalidIter
   where
   fP pos ti _ [] = Just ti -- the remaining bits are zero anyway
   fP pos ti [] _ = Nothing
-  fP pos ti (d:ds) (p:ps) = let idx = fromIntegral (p+1) :: Word in
+  fP pos ti (d:ds) (p:ps) = let idx = fromIntegral (p+1) in
     if idx >= bit d then Nothing else
     fP (pos+d) (setBitSlice ti pos d idx) ds ps
 
@@ -439,7 +437,7 @@ iterNthChild :: Depth -> Int -> TreeIter -> Cache a  ->
                 (Maybe TreeIter, Cache a)
 iterNthChild depth childIdx_ iter cache = let
     (pos,leaf,child) = getTreeIterLeaf depth iter
-    childIdx = fromIntegral childIdx_+1 :: Word
+    childIdx = fromIntegral childIdx_+1
     nextIter = setBitSlice iter (pos+leaf) child childIdx
   in
   if childIdx>=bit child then (Nothing, cache) else

--- a/gtk/Graphics/UI/Gtk/ModelView/Types.chs
+++ b/gtk/Graphics/UI/Gtk/ModelView/Types.chs
@@ -76,6 +76,7 @@ import System.Glib.GObject        (Quark, quarkFromString)
 {#import Graphics.UI.Gtk.Types#}	(TreeModel, TreeModelSort, TreeModelFilter,
                                    Pixbuf)
 import Data.Char ( isDigit )
+import Data.Word (Word32)
 import Control.Monad ( liftM )
 
 {# context lib="gtk" prefix="gtk" #}
@@ -120,7 +121,7 @@ instance TypedTreeModelClass TypedTreeModelFilter
 -- use of the three words is therefore implementation specific. See also
 -- 'TreePath'.
 --
-data TreeIter = TreeIter {-# UNPACK #-} !CInt !Word !Word !Word
+data TreeIter = TreeIter {-# UNPACK #-} !CInt !Word32 !Word32 !Word32
 	      deriving Show
 
 {#pointer *TreeIter as TreeIterPtr -> TreeIter #}
@@ -137,7 +138,7 @@ instance Storable TreeIter where
                            (ptrToWord user_data2)
                            (ptrToWord user_data3))
 
-    where ptrToWord :: Ptr a -> Word
+    where ptrToWord :: Ptr a -> Word32
           ptrToWord ptr = fromIntegral (ptr `minusPtr` nullPtr)
 
   poke ptr (TreeIter stamp user_data user_data2 user_data3) = do
@@ -146,7 +147,7 @@ instance Storable TreeIter where
     {# set TreeIter->user_data2 #} ptr (wordToPtr user_data2)
     {# set TreeIter->user_data3 #} ptr (wordToPtr user_data3)
 
-    where wordToPtr :: Word -> Ptr a
+    where wordToPtr :: Word32 -> Ptr a
           wordToPtr word = nullPtr `plusPtr` fromIntegral word
 
 -- Pass a pointer to a structure large enough to hold a GtkTreeIter


### PR DESCRIPTION
The code in `TreeStore.hs` does bit twiddling on `Word` values which have an unknown number of bits - this PR changes them to use `Word32` which has a known size, which should satisfy the TODO comment there.
