### PR TITLE
Fix build with GHC 7.10

### DIFF
--- a/cairo/SetupWrapper.hs
+++ b/cairo/SetupWrapper.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- A wrapper script for Cabal Setup.hs scripts. Allows compiling the real Setup
 -- conditionally depending on the Cabal version.
 
@@ -18,7 +19,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception

--- a/cairo/SetupWrapper.hs
+++ b/cairo/SetupWrapper.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -- A wrapper script for Cabal Setup.hs scripts. Allows compiling the real Setup
 -- conditionally depending on the Cabal version.
 

--- a/gio/SetupWrapper.hs
+++ b/gio/SetupWrapper.hs
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception

--- a/glib/SetupWrapper.hs
+++ b/glib/SetupWrapper.hs
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception

--- a/gtk/Graphics/UI/Gtk/Gdk/EventM.hsc
+++ b/gtk/Graphics/UI/Gtk/Gdk/EventM.hsc
@@ -1,5 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE EmptyDataDecls #-}
+#if MIN_VERSION_base(4,8,0)
+{-# LANGUAGE FlexibleContexts #-}
+#endif
 -- -*-haskell-*-
 
 #include <gtk/gtk.h>

--- a/gtk/SetupWrapper.hs
+++ b/gtk/SetupWrapper.hs
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception

--- a/pango/SetupWrapper.hs
+++ b/pango/SetupWrapper.hs
@@ -18,7 +18,7 @@ import Distribution.Text
 
 import System.Environment
 import System.Process
-import System.Exit
+import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.Directory
 import qualified Control.Exception as Exception


### PR DESCRIPTION
I had to make a couple of changes to make `gtk`-related build with GHC 7.10:

* I had to explicitly import `ExitSuccess` and `exitWith` from `System.Exit` in `SetupWrapper.hs`, since `System.Exit` exports a `die` function in `base-4.8.0.0`, which conflicts with `die` in `Distribution.Simple.Utils`.
* GHC 7.10 now requires language extensions for inferred type signatures if they require them, so I had to add the `FlexibleContexts` extension to `Graphics.UI.Gtk.Gdk.EventM` in `gtk`(`3`).