### PR TITLE
Build error for package 0.13.5 for GTK2 on Mac OS X 10.10 (Yosemite)

### DIFF
--- a/gtk/Graphics/UI/Gtk/Embedding/Socket.chs
+++ b/gtk/Graphics/UI/Gtk/Embedding/Socket.chs
@@ -94,7 +94,9 @@ module Graphics.UI.Gtk.Embedding.Socket (
   socketNew,
 
 -- * Methods
+#if GTK_MAJOR_VERSION >= 3
   socketHasPlug,
+#endif
   socketAddId,
   socketGetId,
 #if GTK_CHECK_VERSION(2,14,0)

--- a/gtk/Graphics/UI/Gtk/General/Structs.hsc
+++ b/gtk/Graphics/UI/Gtk/General/Structs.hsc
@@ -608,7 +608,7 @@ fromNativeWindowId :: NativeWindowId -> Ptr a
 fromNativeWindowId = castPtr . unNativeWindowId
 nativeWindowIdNone :: NativeWindowId
 nativeWindowIdNone = NativeWindowId nullPtr
-#elif defined(HAVE_QUARTZ_GTK) || defined(GDK_WINDOWING_QUARTZ) || (defined(WIN32) && GTK_MAJOR_VERSION >= 3)
+#elif defined(WIN32) && GTK_MAJOR_VERSION >= 3
 newtype NativeWindowId = NativeWindowId (Maybe DrawWindow) deriving (Eq)
 unNativeWindowId :: NativeWindowId -> Maybe DrawWindow
 unNativeWindowId (NativeWindowId id) = id


### PR DESCRIPTION
```
[207 of 209] Compiling Graphics.UI.Gtk.Embedding.Plug ( dist/build/Graphics/UI/Gtk/Embedding/Plug.hs, dist/build/Graphics/UI/Gtk/Embedding/Plug.o )

Graphics/UI/Gtk/Embedding/Plug.chs:120:6:
    Couldn't match expected type ‘CUInt’
                with actual type ‘Maybe DrawWindow’
    In the first argument of ‘gtk_plug_new’, namely
      ‘(fromNativeWindowId (fromMaybe nativeWindowIdNone socketId))’
    In the second argument of ‘($)’, namely
      ‘gtk_plug_new
         (fromNativeWindowId (fromMaybe nativeWindowIdNone socketId))’

Graphics/UI/Gtk/Embedding/Plug.chs:137:6:
    Couldn't match expected type ‘CUInt’
                with actual type ‘Maybe DrawWindow’
    In the second argument of ‘\ (Display arg1) arg2
                                 -> withForeignPtr arg1
                                    $ \ argPtr1 -> gtk_plug_new_for_display argPtr1 arg2’, namely
      ‘(fromNativeWindowId (fromMaybe nativeWindowIdNone socketId))’
    In the second argument of ‘($)’, namely
      ‘(\ (Display arg1) arg2
          -> withForeignPtr arg1
             $ \ argPtr1 -> gtk_plug_new_for_display argPtr1 arg2)
         display
         (fromNativeWindowId (fromMaybe nativeWindowIdNone socketId))’

Graphics/UI/Gtk/Embedding/Plug.chs:151:3:
    Couldn't match type ‘CUInt’ with ‘Maybe DrawWindow’
    Expected type: IO (Maybe DrawWindow)
      Actual type: IO CUInt
    In the second argument of ‘($)’, namely
      ‘(\ (Plug arg1)
          -> withForeignPtr arg1 $ \ argPtr1 -> gtk_plug_get_id argPtr1)
         (toPlug self)’
    In the expression:
      liftM toNativeWindowId
      $ (\ (Plug arg1)
           -> withForeignPtr arg1 $ \ argPtr1 -> gtk_plug_get_id argPtr1)
          (toPlug self)
cabal: Error: some packages failed to install:
```