### PR TITLE
Bump utf8-string upper version bounds

### DIFF
--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -46,7 +46,7 @@ Flag cairo_svg
   
 Library
         build-depends:  base >= 4 && < 5,
-                        utf8-string >= 0.2 && < 0.4,
+                        utf8-string >= 0.2 && < 1.1,
                         text >= 1.0.0.0 && < 1.3,
                         bytestring, mtl, array
         build-tools:    gtk2hsC2hs >= 0.13.12

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -34,7 +34,7 @@ Flag closure_signals
 
 Library
         build-depends:  base >= 4 && < 5,
-                        utf8-string >= 0.2 && < 0.4,
+                        utf8-string >= 0.2 && < 1.1,
                         bytestring >= 0.9.1.10 && < 0.11,
                         text >= 1.0.0.0 && < 1.3,
                         containers


### PR DESCRIPTION
Allow `cairo` and `glib` to build with `utf8-string-1`.