### PR TITLE
Better way to handle binary mode on windows

### DIFF
--- a/gtk/Graphics/UI/Gtk/General/hsgthread.c
+++ b/gtk/Graphics/UI/Gtk/General/hsgthread.c
@@ -72,7 +72,20 @@ void gtk2hs_initialise (void) {
 #if defined( WIN32 ) && defined( GTK2HS_SET_FMODE_BINARY )
 	/* Some Windows GTK binraries (current Fedora MinGW ones) do */
 	/* not open files in binary mode.  This is a work around.    */
-    _fmode = _O_BINARY;
+    HANDLE handle = LoadLibrary("MSVCRT.dll");
+    if(!handle) { 
+        fprintf(stderr, "Warning: failed to load MSVCRT.dll, ");
+        fprintf(stderr, "binary mode was not set!\n");
+        return;
+    }
+    
+    int *_fmode_ptr = GetProcAddress(handle, "_fmode");
+    if(!_fmode_ptr) {
+        fprintf(stderr, "Warning: failed to load address of _fmode from MSVCRT.dll, ");
+        fprintf(stderr, "binary mode was not set!\n");
+        return;
+    }
+    *_fmode_ptr = _O_BINARY;
 #endif
 }
 


### PR DESCRIPTION
The old way of setting binary mode didn't work in GHCi.

That meant you could either have gtk that works properly with image files but doesn't work in GHCi or one that works in GHCi but fails to open most image files due to bug with g_fopen in glib: see https://bugzilla.gnome.org/show_bug.cgi?id=745155.

So instead of relying on GHCi linker to resolve _fmode symbol (which fails because its being exported with __declspec(dllimport) and that apparently isn't supported by GHCi linker) lets load it dynamically using win32 api.