### PR TITLE
Lower cabal-version bound

### DIFF
--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -6,7 +6,7 @@ Copyright:      (c) 2001-2010 The Gtk2Hs Team, (c) Paolo Martini 2005, (c) Abrah
 Author:         Axel Simon, Duncan Coutts
 Maintainer:     gtk2hs-users@lists.sourceforge.net
 Build-Type:     Custom
-Cabal-Version:  >= 1.18
+Cabal-Version:  >= 1.10
 Stability:      stable
 homepage:       http://projects.haskell.org/gtk2hs/
 bug-reports:    https://github.com/gtk2hs/gtk2hs/issues


### PR DESCRIPTION
There were no significant changes between  cabal-version1.10 and 1.20, so a higher bound than 1.10 just prevents users with older cabals from installing the package.