### PR TITLE
Fix CPP flags for MinGW systems

### DIFF
--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -371,6 +371,9 @@ Library
           cc-options:     -fno-exceptions
           extra-libraries: kernel32
 
+        if os(windows)
+          cpp-options: -D__USE_MINGW_ANSI_STDIO=1
+
         x-c2hs-Header:  hsgtk.h
         x-Types-Hierarchy:  hierarchy3.list
 

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -76,6 +76,8 @@ Library
         includes:       hspango.h
         include-dirs:   .
         cpp-options:    -U__BLOCKS__ -D__attribute__(A)=
+        if os(windows)
+          cpp-options: -D__USE_MINGW_ANSI_STDIO=1
         -- Pango 1.26 has a mysterious bug that makes it go into an infinite
         -- loop. Don't allow the user to build against this version. (Omit the
         -- >= 1.0 constraint in this case since Cabal 1.6 can't parse it.)


### PR DESCRIPTION
Resolves #110. ANSI compatible printf is required for template-hsc-gtk2hs.h to function correctly.

If we can get this cleared and pushed to Hackage and Stackage, I think we'll finally be able to claim that installing gtk2hs on Windows is easy. I'm working up a new set of MSYS2-based instructions for the Wiki.