### PR TITLE
Fix CPP flags for gtk on MinGW

### DIFF
--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -390,6 +390,9 @@ Library
           cc-options:     -fno-exceptions
           extra-libraries: kernel32
 
+        if os(windows)
+          cpp-options: -D__USE_MINGW_ANSI_STDIO=1
+
         x-c2hs-Header:  hsgtk.h
         x-Types-Hierarchy:  hierarchy.list
 


### PR DESCRIPTION
This copies the changes made in #113 to `gtk.cabal-renamed`. Think of this as part 2 of #110.