### PR TITLE
Only use -D__attribute__(A)= on Darwin

### DIFF
--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -79,7 +79,10 @@ Library
         default-language:   Haskell98
         default-extensions: ForeignFunctionInterface
 		
-        cpp-options:    -U__BLOCKS__ -Ubool -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__ -Ubool
+        if os(darwin)
+          cpp-options: -D__attribute__(A)=
+
         x-Signals-File:  System/GIO/Signals.chs
         x-Signals-Modname: System.GIO.Signals
         x-Signals-Types: marshal.list

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -39,7 +39,9 @@ Library
                         text >= 1.0.0.0 && < 1.3,
                         containers
         build-tools:    gtk2hsC2hs >= 0.13.13
-        cpp-options:    -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__
+        if os(darwin)
+          cpp-options: -D__attribute__(A)=
         if flag(closure_signals)
           cpp-options:  -DUSE_GCLOSURE_SIGNALS_IMPL
           c-sources: System/Glib/hsgclosure.c

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -380,7 +380,9 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -U__BLOCKS__
+        if os(darwin)
+          cpp-options: -D__attribute__(A)=
         if !flag(deprecated)
           cpp-options:  -DDISABLE_DEPRECATED
         else

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -366,7 +366,9 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__
+        if os(darwin)
+          cpp-options: -D__attribute__(A)=
         if os(windows)
           cpp-options:    -DWIN32 -fno-exceptions
           cc-options:     -fno-exceptions

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -75,7 +75,9 @@ Library
         x-c2hs-Header:  hspango.h
         includes:       hspango.h
         include-dirs:   .
-        cpp-options:    -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__
+        if os(darwin)
+          cpp-options: -D__attribute__(A)=
         if os(windows)
           cpp-options: -D__USE_MINGW_ANSI_STDIO=1
         -- Pango 1.26 has a mysterious bug that makes it go into an infinite


### PR DESCRIPTION
I'm currently trying to get ghc-vis running on Windows again, with GTK+3.

This was introduced as an OS X fix, so I kept it enabled for Darwin only: https://github.com/def-/gtk2hs/commit/1bd4d95473a3e8856f13bfbd796024465c1bc068

But it breaks compilation on msys2 on Windows, as described here: https://mail.haskell.org/pipermail/haskell-cafe/2015-October/121935.html

No idea if this is reasonable or another solution would be better.