### PR TITLE
Fix GHC 8.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.2
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
   allow_failures:

--- a/cairo/Gtk2HsSetup.hs
+++ b/cairo/Gtk2HsSetup.hs
@@ -183,11 +183,16 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace
-#if CABAL_VERSION_CHECK(1,10,0)
-                                    packageDbs
+#if CABAL_VERSION_CHECK(1,23,0)
+                                   (LBI.compiler lbi) (withPrograms lbi)
+                                   False packageDbs installedPkgInfo
 #else
-                                    packageDb
+                                   installedPkgInfo pkg lbi inplace
+# if CABAL_VERSION_CHECK(1,10,0)
+                                   packageDbs
+# else
+                                   packageDb
+# endif
 #endif
 
   where

--- a/cairo/Gtk2HsSetup.hs
+++ b/cairo/Gtk2HsSetup.hs
@@ -22,7 +22,11 @@ import Distribution.InstalledPackageInfo ( importDirs,
                                            libraryDirs,
                                            extraLibraries,
                                            extraGHCiLibraries )
+#if CABAL_VERSION_CHECK(1,23,0)
+import Distribution.Simple.PackageIndex ( lookupUnitId )
+#else
 import Distribution.Simple.PackageIndex ( lookupInstalledPackageId )
+#endif
 import Distribution.PackageDescription as PD ( PackageDescription(..),
                                                updatePackageDescription,
                                                BuildInfo(..),
@@ -184,14 +188,14 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
 #if CABAL_VERSION_CHECK(1,23,0)
-                                   (LBI.compiler lbi) (withPrograms lbi)
-                                   False packageDbs installedPkgInfo
+                                    (LBI.compiler lbi) (withPrograms lbi)
+                                    False packageDbs installedPkgInfo
 #else
-                                   installedPkgInfo pkg lbi inplace
+                                    installedPkgInfo pkg lbi inplace
 # if CABAL_VERSION_CHECK(1,10,0)
-                                   packageDbs
+                                    packageDbs
 # else
-                                   packageDb
+                                    packageDb
 # endif
 #endif
 
@@ -254,7 +258,14 @@ runC2HS bi lbi (inDir, inFile)  (outDir, outFile) verbosity = do
   -- we assume that these are installed in the same place as .hi files
   let chiDirs = [ dir |
                   ipi <- maybe [] (map fst . componentPackageDeps) (libraryConfig lbi),
-                  dir <- maybe [] importDirs (lookupInstalledPackageId (installedPkgs lbi) ipi) ]
+                  dir <- maybe [] importDirs $
+#if CABAL_VERSION_CHECK(1,23,0)
+                           lookupUnitId
+#else
+                           lookupInstalledPackageId
+#endif
+                             (installedPkgs lbi) ipi
+                ]
   (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
   rawSystemProgramConf verbosity c2hsLocal (withPrograms lbi) $
        map ("--include=" ++) (outDir:chiDirs)

--- a/gio/Gtk2HsSetup.hs
+++ b/gio/Gtk2HsSetup.hs
@@ -183,11 +183,16 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace
-#if CABAL_VERSION_CHECK(1,10,0)
-                                    packageDbs
+#if CABAL_VERSION_CHECK(1,23,0)
+                                   (LBI.compiler lbi) (withPrograms lbi)
+                                   False packageDbs installedPkgInfo
 #else
-                                    packageDb
+                                   installedPkgInfo pkg lbi inplace
+# if CABAL_VERSION_CHECK(1,10,0)
+                                   packageDbs
+# else
+                                   packageDb
+# endif
 #endif
 
   where

--- a/gio/Gtk2HsSetup.hs
+++ b/gio/Gtk2HsSetup.hs
@@ -22,7 +22,11 @@ import Distribution.InstalledPackageInfo ( importDirs,
                                            libraryDirs,
                                            extraLibraries,
                                            extraGHCiLibraries )
+#if CABAL_VERSION_CHECK(1,23,0)
+import Distribution.Simple.PackageIndex ( lookupUnitId )
+#else
 import Distribution.Simple.PackageIndex ( lookupInstalledPackageId )
+#endif
 import Distribution.PackageDescription as PD ( PackageDescription(..),
                                                updatePackageDescription,
                                                BuildInfo(..),
@@ -184,14 +188,14 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
 #if CABAL_VERSION_CHECK(1,23,0)
-                                   (LBI.compiler lbi) (withPrograms lbi)
-                                   False packageDbs installedPkgInfo
+                                    (LBI.compiler lbi) (withPrograms lbi)
+                                    False packageDbs installedPkgInfo
 #else
-                                   installedPkgInfo pkg lbi inplace
+                                    installedPkgInfo pkg lbi inplace
 # if CABAL_VERSION_CHECK(1,10,0)
-                                   packageDbs
+                                    packageDbs
 # else
-                                   packageDb
+                                    packageDb
 # endif
 #endif
 
@@ -254,7 +258,14 @@ runC2HS bi lbi (inDir, inFile)  (outDir, outFile) verbosity = do
   -- we assume that these are installed in the same place as .hi files
   let chiDirs = [ dir |
                   ipi <- maybe [] (map fst . componentPackageDeps) (libraryConfig lbi),
-                  dir <- maybe [] importDirs (lookupInstalledPackageId (installedPkgs lbi) ipi) ]
+                  dir <- maybe [] importDirs $
+#if CABAL_VERSION_CHECK(1,23,0)
+                           lookupUnitId
+#else
+                           lookupInstalledPackageId
+#endif
+                             (installedPkgs lbi) ipi
+                ]
   (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
   rawSystemProgramConf verbosity c2hsLocal (withPrograms lbi) $
        map ("--include=" ++) (outDir:chiDirs)

--- a/glib/Gtk2HsSetup.hs
+++ b/glib/Gtk2HsSetup.hs
@@ -183,11 +183,16 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace
-#if CABAL_VERSION_CHECK(1,10,0)
-                                    packageDbs
+#if CABAL_VERSION_CHECK(1,23,0)
+                                    (LBI.compiler lbi) (withPrograms lbi)
+                                    False packageDbs installedPkgInfo
 #else
+                                    installedPkgInfo pkg lbi inplace
+# if CABAL_VERSION_CHECK(1,10,0)
+                                    packageDbs
+# else
                                     packageDb
+# endif
 #endif
 
   where

--- a/gtk/Gtk2HsSetup.hs
+++ b/gtk/Gtk2HsSetup.hs
@@ -183,11 +183,16 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace
-#if CABAL_VERSION_CHECK(1,10,0)
-                                    packageDbs
+#if CABAL_VERSION_CHECK(1,23,0)
+                                   (LBI.compiler lbi) (withPrograms lbi)
+                                   False packageDbs installedPkgInfo
 #else
-                                    packageDb
+                                   installedPkgInfo pkg lbi inplace
+# if CABAL_VERSION_CHECK(1,10,0)
+                                   packageDbs
+# else
+                                   packageDb
+# endif
 #endif
 
   where

--- a/gtk/Gtk2HsSetup.hs
+++ b/gtk/Gtk2HsSetup.hs
@@ -22,7 +22,11 @@ import Distribution.InstalledPackageInfo ( importDirs,
                                            libraryDirs,
                                            extraLibraries,
                                            extraGHCiLibraries )
+#if CABAL_VERSION_CHECK(1,23,0)
+import Distribution.Simple.PackageIndex ( lookupUnitId )
+#else
 import Distribution.Simple.PackageIndex ( lookupInstalledPackageId )
+#endif
 import Distribution.PackageDescription as PD ( PackageDescription(..),
                                                updatePackageDescription,
                                                BuildInfo(..),
@@ -184,14 +188,14 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
 #if CABAL_VERSION_CHECK(1,23,0)
-                                   (LBI.compiler lbi) (withPrograms lbi)
-                                   False packageDbs installedPkgInfo
+                                    (LBI.compiler lbi) (withPrograms lbi)
+                                    False packageDbs installedPkgInfo
 #else
-                                   installedPkgInfo pkg lbi inplace
+                                    installedPkgInfo pkg lbi inplace
 # if CABAL_VERSION_CHECK(1,10,0)
-                                   packageDbs
+                                    packageDbs
 # else
-                                   packageDb
+                                    packageDb
 # endif
 #endif
 
@@ -254,7 +258,14 @@ runC2HS bi lbi (inDir, inFile)  (outDir, outFile) verbosity = do
   -- we assume that these are installed in the same place as .hi files
   let chiDirs = [ dir |
                   ipi <- maybe [] (map fst . componentPackageDeps) (libraryConfig lbi),
-                  dir <- maybe [] importDirs (lookupInstalledPackageId (installedPkgs lbi) ipi) ]
+                  dir <- maybe [] importDirs $
+#if CABAL_VERSION_CHECK(1,23,0)
+                           lookupUnitId
+#else
+                           lookupInstalledPackageId
+#endif
+                             (installedPkgs lbi) ipi
+                ]
   (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
   rawSystemProgramConf verbosity c2hsLocal (withPrograms lbi) $
        map ("--include=" ++) (outDir:chiDirs)

--- a/pango/Gtk2HsSetup.hs
+++ b/pango/Gtk2HsSetup.hs
@@ -183,11 +183,16 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace
-#if CABAL_VERSION_CHECK(1,10,0)
-                                    packageDbs
+#if CABAL_VERSION_CHECK(1,23,0)
+                                   (LBI.compiler lbi) (withPrograms lbi)
+                                   False packageDbs installedPkgInfo
 #else
-                                    packageDb
+                                   installedPkgInfo pkg lbi inplace
+# if CABAL_VERSION_CHECK(1,10,0)
+                                   packageDbs
+# else
+                                   packageDb
+# endif
 #endif
 
   where

--- a/pango/Gtk2HsSetup.hs
+++ b/pango/Gtk2HsSetup.hs
@@ -22,7 +22,11 @@ import Distribution.InstalledPackageInfo ( importDirs,
                                            libraryDirs,
                                            extraLibraries,
                                            extraGHCiLibraries )
+#if CABAL_VERSION_CHECK(1,23,0)
+import Distribution.Simple.PackageIndex ( lookupUnitId )
+#else
 import Distribution.Simple.PackageIndex ( lookupInstalledPackageId )
+#endif
 import Distribution.PackageDescription as PD ( PackageDescription(..),
                                                updatePackageDescription,
                                                BuildInfo(..),
@@ -184,14 +188,14 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
        | modeGenerateRegScript -> die "Generate Reg Script not supported"
        | otherwise             -> registerPackage verbosity
 #if CABAL_VERSION_CHECK(1,23,0)
-                                   (LBI.compiler lbi) (withPrograms lbi)
-                                   False packageDbs installedPkgInfo
+                                    (LBI.compiler lbi) (withPrograms lbi)
+                                    False packageDbs installedPkgInfo
 #else
-                                   installedPkgInfo pkg lbi inplace
+                                    installedPkgInfo pkg lbi inplace
 # if CABAL_VERSION_CHECK(1,10,0)
-                                   packageDbs
+                                    packageDbs
 # else
-                                   packageDb
+                                    packageDb
 # endif
 #endif
 
@@ -254,7 +258,14 @@ runC2HS bi lbi (inDir, inFile)  (outDir, outFile) verbosity = do
   -- we assume that these are installed in the same place as .hi files
   let chiDirs = [ dir |
                   ipi <- maybe [] (map fst . componentPackageDeps) (libraryConfig lbi),
-                  dir <- maybe [] importDirs (lookupInstalledPackageId (installedPkgs lbi) ipi) ]
+                  dir <- maybe [] importDirs $
+#if CABAL_VERSION_CHECK(1,23,0)
+                           lookupUnitId
+#else
+                           lookupInstalledPackageId
+#endif
+                             (installedPkgs lbi) ipi
+                ]
   (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
   rawSystemProgramConf verbosity c2hsLocal (withPrograms lbi) $
        map ("--include=" ++) (outDir:chiDirs)


### PR DESCRIPTION
An attempt at making the various `gtk` libraries compile with GHC 8.0. This uses a somewhat gross hack in the `SetupWrapper.hs` scripts in order to avoid the use of CPP, so please review to make sure that is an acceptable fix.

Fixes #154.