### PR TITLE
Fix gio build on Windows with GHC 7.10.3

### DIFF
--- a/gio/System/GIO/File/IOError.chs
+++ b/gio/System/GIO/File/IOError.chs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 --  GIMP Toolkit (GTK) Binding for Haskell: binding to gio -*-haskell-*-
 --
 --  Author : Andy Stewart


### PR DESCRIPTION
Since `errno` is a CPP macro in a recent version of MinGW-w64 that is shipped with GHC 7.10.3 on Windows, we want to avoid expanding its definition. This accomplishes that in `System.GIO.File.IOError`, which only needs `gtk2hs-buildtools` but not the `CPP` extension, which causes `errno` to be expanded unnecessarily.