### PR TITLE
gridSetColumnHomogeneous must call grid_set_column_homogeneous

### DIFF
--- a/gtk/Graphics/UI/Gtk/Layout/Grid.chs
+++ b/gtk/Graphics/UI/Gtk/Layout/Grid.chs
@@ -201,7 +201,7 @@ gridSetColumnHomogeneous :: GridClass self
  -> Bool -- ^ @homogeneous@ - True to make columns homogeneous.
  -> IO ()
 gridSetColumnHomogeneous self homogeneous =
- {# call grid_set_row_homogeneous #}
+ {# call grid_set_column_homogeneous #}
     (toGrid self)
     (fromBool homogeneous)
 


### PR DESCRIPTION
Currently `gridSetColumnHomogeneous` calls `grid_set_row_homogeneous` instead of `grid_set_column_homogeneous`.