### PR TITLE
Implement Interface for GtkStack and GtkStackSwitcher

### DIFF
--- a/gtk/Graphics/UI/Gtk.chs
+++ b/gtk/Graphics/UI/Gtk.chs
@@ -229,6 +229,10 @@ module Graphics.UI.Gtk (
   module Graphics.UI.Gtk.Layout.VBox,
   module Graphics.UI.Gtk.Layout.VButtonBox,
   module Graphics.UI.Gtk.Layout.VPaned,
+#if GTK_CHECK_VERSION(3,10,0)
+  module Graphics.UI.Gtk.Layout.Stack,
+  module Graphics.UI.Gtk.Layout.StackSwitcher,
+#endif
   -- * Ornaments
   module Graphics.UI.Gtk.Ornaments.Frame,
   module Graphics.UI.Gtk.Ornaments.HSeparator,
@@ -489,6 +493,10 @@ import Graphics.UI.Gtk.Layout.Notebook
 #if GTK_MAJOR_VERSION >= 3
 import Graphics.UI.Gtk.Layout.Grid
 import Graphics.UI.Gtk.Layout.Overlay
+#endif
+#if GTK_CHECK_VERSION(3,10,0)
+import Graphics.UI.Gtk.Layout.Stack
+import Graphics.UI.Gtk.Layout.StackSwitcher
 #endif
 import Graphics.UI.Gtk.Layout.Expander
 import Graphics.UI.Gtk.Layout.Table

--- a/gtk/Graphics/UI/Gtk/General/Enums.chs
+++ b/gtk/Graphics/UI/Gtk/General/Enums.chs
@@ -111,6 +111,9 @@ module Graphics.UI.Gtk.General.Enums (
 #if GTK_MAJOR_VERSION < 3
   AnchorType (..),
 #endif
+#if GTK_CHECK_VERSION(3,10,0)
+  StackTransitionType (..),
+#endif
 
 module Graphics.UI.Gtk.Gdk.Enums
   ) where
@@ -507,4 +510,8 @@ instance Flags TextSearchFlags
 --
 -- Removed in Gtk3.
 {#enum AnchorType {underscoreToCase} deriving (Eq,Show)#}
+#endif
+
+#if GTK_CHECK_VERSION(3,10,0)
+{#enum StackTransitionType {underscoreToCase} deriving (Eq,Show)#}
 #endif

--- a/gtk/Graphics/UI/Gtk/Layout/Stack.chs
+++ b/gtk/Graphics/UI/Gtk/Layout/Stack.chs
@@ -1,0 +1,406 @@
+{-# LANGUAGE CPP #-}
+-- -*-haskell-*-
+--  GIMP Toolkit (GTK) Widgets Stack
+--
+--  Author : Moritz Schulte
+--
+--  Created: 27 April 2016
+--
+--  Copyright (C) 2015 Moritz Schulte
+--
+--  This library is free software; you can redistribute it and/or
+--  modify it under the terms of the GNU Lesser General Public
+--  License as published by the Free Software Foundation; either
+--  version 2.1 of the License, or (at your option) any later version.
+--
+--  This library is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+--  Lesser General Public License for more details.
+--
+-- |
+-- Maintainer  : gtk2hs-users@lists.sourceforge.net
+-- Stability   : provisional
+-- Portability : portable (depends on GHC)
+--
+-- A widget which controls the alignment and size of its child
+--
+module Graphics.UI.Gtk.Layout.Stack (
+-- * Detail
+--
+-- The 'Stack' widget is a container which only shows one of its
+-- children at a time. In contrast to 'Notebook', 'Stack' does not
+-- provide a means for users to change the visible child. Instead, the
+-- 'StackSwitcher' widget can be used with 'Stack' to provide this
+-- functionality.
+--
+-- Transitions between pages can be animated as slides or fades. This
+-- can be controlled with 'stackSetTransitionType'. These
+-- animations respect the 'gtk-enable-animations' setting.
+--       
+-- The GtkStack widget was added in GTK+ 3.10.
+--
+-- * Class Hierarchy
+-- |
+-- @
+-- |  'GObject'
+-- |   +----'Object'
+-- |         +----'Widget'
+-- |               +----'Container'
+-- |                     +----'Stack'
+-- @
+
+-- * Types
+#if GTK_CHECK_VERSION(3,10,0)
+         Stack
+       , castToStack
+       , gTypeStack
+       , toStack
+       , StackTransitionType(..)
+-- * Constructors
+       , stackNew
+
+-- * Methods
+       , stackAddNamed
+       , stackAddTitled
+       , stackGetTransitionType
+       , stackSetTransitionType
+       , stackSetTransitionDuration
+       , stackGetTransitionDuration
+       , stackGetChildByName
+       , stackSetVisibleChild
+       , stackSetVisibleChildName
+       , stackGetVisibleChildName
+       , stackSetVisibleChildFull
+       , stackSetHomogeneous
+       , stackGetHomogeneous
+       , stackSetHhomogeneous
+       , stackGetHhomogeneous
+       , stackSetVhomogeneous
+       , stackGetVhomogeneous
+       , stackGetTransitionRunning
+       , stackSetInterpolateSize
+       , stackGetInterpolateSize
+
+-- * Attributes
+       , stackHhomogeneous
+       , stackHomogeneous
+       , stackInterpolateSize
+       , stackTransitionDuration
+       , stackTransitionRunning
+       , stackTransitionType
+       , stackVhomogeneous
+       , stackVisibleChild
+       , stackVisibleChildName
+#endif
+) where
+
+#if GTK_CHECK_VERSION(3,10,0)
+
+import Control.Monad    (liftM)
+
+import System.Glib.FFI
+import System.Glib.UTFString
+import System.Glib.Attributes
+import System.Glib.Properties
+import Graphics.UI.Gtk.Abstract.Object  (makeNewObject)
+import Graphics.UI.Gtk.General.Enums    (StackTransitionType(..))
+{#import Graphics.UI.Gtk.Types#}
+
+{# context lib="gtk" prefix="gtk" #}
+
+--------------------
+-- Constructors
+
+-- | Creates a new 'Stack' container.
+--
+stackNew :: IO Stack
+stackNew =
+  makeNewObject mkStack $
+  liftM (castPtr :: Ptr Widget -> Ptr Stack) $
+  {# call unsafe stack_new #}
+
+--------------------
+-- Methods
+
+-- | Adds a child to stack . The child is identified by the name.
+stackAddNamed :: (StackClass self, WidgetClass child, GlibString name) => self
+ -> child
+ -> name
+ -> IO ()
+stackAddNamed self child name =
+  withUTFString name $ \namePtr ->
+    {# call stack_add_named  #}
+      (toStack self)
+      (toWidget child)
+      namePtr
+
+-- | Adds a child to stack. The child is identified by the name. The
+-- title will be used by 'StackSwitcher' to represent child in a tab
+-- bar, so it should be short.
+stackAddTitled :: (StackClass self, WidgetClass child,
+                   GlibString name, GlibString title) => self
+ -> child
+ -> name
+ -> title
+ -> IO ()
+stackAddTitled self child name title =
+  withUTFString name $ \namePtr ->
+    withUTFString title $ \titlePtr ->
+      {# call stack_add_titled  #}
+        (toStack self)
+        (toWidget child)
+        namePtr
+        titlePtr
+
+-- | Sets the type of animation that will be used for transitions
+-- between pages in stack . Available types include various kinds of
+-- fades and slides. The transition type can be changed without
+-- problems at runtime, so it is possible to change the animation
+-- based on the page that is about to become current.
+stackSetTransitionType :: StackClass self => self
+ -> StackTransitionType
+ -> IO ()
+stackSetTransitionType self transitionType =
+  {# call unsafe stack_set_transition_type #}
+    (toStack self)
+    (fromIntegral $ fromEnum transitionType)
+
+-- | Gets the type of animation that will be used for transitions
+-- between pages in stack.
+stackGetTransitionType :: StackClass self => self
+ -> IO StackTransitionType
+stackGetTransitionType self =
+  liftM (toEnum . fromIntegral) $
+  {# call unsafe stack_get_transition_type #}
+    (toStack self)
+
+-- | Sets the duration that transitions between pages in stack will
+-- take.
+stackSetTransitionDuration :: StackClass self => self
+ -> Int
+ -> IO ()
+stackSetTransitionDuration self duration =
+  {# call unsafe stack_set_transition_duration #}
+    (toStack self)
+    (fromIntegral duration)
+
+-- | Returns the amount of time (in milliseconds) that transitions
+-- between pages in stack will take.
+stackGetTransitionDuration :: StackClass self => self
+ -> IO Int
+stackGetTransitionDuration self =
+  liftM fromIntegral $
+  {# call unsafe stack_get_transition_duration #}
+    (toStack self)
+
+-- | Finds the child of the GtkStack with the name given as the
+-- argument. Returns Nothing if there is no child with this name.
+stackGetChildByName :: (StackClass self, GlibString name) => self
+ -> name
+ -> IO Widget
+stackGetChildByName self name =
+  withUTFString name $ \namePtr ->
+    makeNewObject mkWidget $
+    {# call unsafe stack_get_child_by_name #}
+      (toStack self)
+      namePtr
+
+-- | Gets Just the currently visible child of stack, or Nothing if
+-- there are no visible children.
+stackGetVisibleChild :: StackClass self => self
+ -> IO (Maybe Widget)
+stackGetVisibleChild self =
+  maybeNull (makeNewObject mkWidget) $
+  {# call unsafe stack_get_visible_child #}
+    (toStack self)
+
+-- | Makes child the visible child of stack. If child is different
+-- from the currently visible child, the transition between the two
+-- will be animated with the current transition type of stack. Note
+-- that the child widget has to be visible itself (see 'widgetShow')
+-- in order to become the visible child of stack.
+stackSetVisibleChild :: (StackClass self, WidgetClass child) => self
+ -> child
+ -> IO ()
+stackSetVisibleChild self child =
+    {# call unsafe stack_set_visible_child #}
+      (toStack self)
+      (toWidget child)
+
+-- | Makes the child with the given name visible.  If child is
+-- different from the currently visible child, the transition between
+-- the two will be animated with the current transition type of stack.
+-- Note that the child widget has to be visible itself (see
+-- `widgetShow') in order to become the visible child of stack.
+stackSetVisibleChildName :: (StackClass self, GlibString name) => self
+ -> name
+ -> IO ()
+stackSetVisibleChildName self name =
+  withUTFString name $ \namePtr ->
+    {# call unsafe stack_set_visible_child_name #}
+      (toStack self)
+      namePtr
+
+-- | Returns the name of the currently visible child of stack, or
+-- Nothing if there is no visible child.
+stackGetVisibleChildName :: (StackClass self, GlibString name) => self
+ -> IO (Maybe name)
+stackGetVisibleChildName self =
+  {# call unsafe stack_get_visible_child_name #}
+      (toStack self)
+  >>= maybePeekUTFString
+
+-- | Makes the child with the given name visible.  Note that the child
+-- widget has to be visible itself (see 'widgetShow') in order to
+-- become the visible child of stack .
+stackSetVisibleChildFull :: (StackClass self, GlibString name) => self
+ -> name
+ -> StackTransitionType
+ -> IO ()
+stackSetVisibleChildFull self name transitionType =
+  withUTFString name $ \namePtr ->
+    {# call unsafe stack_set_visible_child_full #}
+      (toStack self)
+      namePtr
+      (fromIntegral $ fromEnum transitionType)
+
+-- | Sets the stack to be homogeneous or not. If it is homogeneous,
+-- the stack will request the same size for all its children. If it
+-- isn't, the stack may change size when a different child becomes
+-- visible.
+stackSetHomogeneous :: StackClass self => self -> Bool -> IO ()
+stackSetHomogeneous self homogeneous =
+  {# call stack_set_homogeneous #}
+    (toStack self)
+    (fromBool homogeneous)
+
+-- | Gets whether stack is homogeneous. See 'stackSetHomogeneous'.
+stackGetHomogeneous :: StackClass self => self -> IO Bool
+stackGetHomogeneous self =
+  liftM toBool $
+  {# call stack_get_homogeneous #}
+    (toStack self)
+
+-- | Sets the stack to be horizontally homogeneous or not. If it is
+-- homogeneous, the stack will request the same width for all its
+-- children. If it isn't, the stack may change width when a different
+-- child becomes visible.
+stackSetHhomogeneous :: StackClass self => self -> Bool -> IO ()
+stackSetHhomogeneous self hhomogeneous =
+  {# call stack_set_hhomogeneous #}
+    (toStack self)
+    (fromBool hhomogeneous)
+
+-- | Gets whether stack is horizontally homogeneous. See
+-- 'stackSetHhomogeneous'.
+stackGetHhomogeneous :: StackClass self => self -> IO Bool
+stackGetHhomogeneous self =
+  liftM toBool $
+  {# call stack_get_hhomogeneous #}
+    (toStack self)
+
+-- | Sets the stack to be vertically homogeneous or not. If it is
+-- homogeneous, the stack will request the same height for all its
+-- children. If it isn't, the stack may change height when a different
+-- child becomes visible.
+stackSetVhomogeneous :: StackClass self => self -> Bool -> IO ()
+stackSetVhomogeneous self vhomogeneous =
+  {# call stack_set_vhomogeneous #}
+    (toStack self)
+    (fromBool vhomogeneous)
+
+-- | Gets whether stack is vertically homogeneous. See
+-- 'stackSetVhomogeneous'.
+stackGetVhomogeneous :: StackClass self => self -> IO Bool
+stackGetVhomogeneous self =
+  liftM toBool $
+  {# call stack_get_vhomogeneous #}
+    (toStack self)
+
+-- | Returns whether the stack is currently in a transition from one
+-- page to another.
+stackGetTransitionRunning :: StackClass self => self -> IO Bool
+stackGetTransitionRunning self =
+  liftM toBool $
+  {# call stack_get_transition_running #}
+    (toStack self)
+
+-- | Returns wether the stack is set up to interpolate between the
+-- sizes of children on page switch.
+stackGetInterpolateSize :: StackClass self => self -> IO Bool
+stackGetInterpolateSize self =
+  liftM toBool $
+  {# call stack_get_interpolate_size #}
+    (toStack self)
+
+-- | Sets whether or not the stack will interpolate its size when
+-- changing the visible child. If the 'interpolate-size' property is
+-- set to True, stack will interpolate its size between the current
+-- one and the one it'll take after changing the visible child,
+-- according to the set transition duration.
+stackSetInterpolateSize :: StackClass self => self -> Bool -> IO ()
+stackSetInterpolateSize self interpolateSize =
+  {# call stack_set_interpolate_size #}
+    (toStack self)
+    (fromBool interpolateSize)
+
+--------------------
+-- Attributes
+
+-- | True if the stack allocates the same width for all children.
+stackHhomogeneous :: StackClass self => Attr self Bool
+stackHhomogeneous = newAttr
+  stackGetHhomogeneous
+  stackSetHhomogeneous
+
+-- | Homogeneous sizing.
+stackHomogeneous :: StackClass self => Attr self Bool
+stackHomogeneous = newAttr
+  stackGetHomogeneous
+  stackSetHomogeneous
+
+-- | Whether or not the size should smoothly change when changing
+-- between differently sized children.
+stackInterpolateSize :: StackClass self => Attr self Bool
+stackInterpolateSize = newAttr
+  stackGetInterpolateSize
+  stackSetInterpolateSize
+
+-- | The animation duration, in milliseconds.
+stackTransitionDuration :: StackClass self => Attr self Int
+stackTransitionDuration = newAttr
+  stackGetTransitionDuration
+  stackSetTransitionDuration
+
+-- | Whether or not the transition is currently running.
+stackTransitionRunning :: StackClass self => ReadAttr self Bool
+stackTransitionRunning = readAttr
+  stackGetTransitionRunning
+
+-- | The type of animation used to transition.
+stackTransitionType :: StackClass self => Attr self StackTransitionType
+stackTransitionType = newAttr
+  stackGetTransitionType
+  stackSetTransitionType
+
+-- | True if the stack allocates the same height for all children.
+stackVhomogeneous :: StackClass self => Attr self Bool
+stackVhomogeneous = newAttr
+  stackGetVhomogeneous
+  stackSetVhomogeneous
+
+-- | The widget currently visible in the stack.
+stackVisibleChild :: StackClass self =>
+  ReadWriteAttr self (Maybe Widget) Widget
+stackVisibleChild = newAttr
+  stackGetVisibleChild
+  stackSetVisibleChild
+
+-- | The name of the widget currently visible in the stack.
+stackVisibleChildName :: StackClass self => ReadWriteAttr self (Maybe String) String
+stackVisibleChildName = newAttr
+  stackGetVisibleChildName
+  stackSetVisibleChildName
+
+#endif

--- a/gtk/Graphics/UI/Gtk/Layout/StackSwitcher.chs
+++ b/gtk/Graphics/UI/Gtk/Layout/StackSwitcher.chs
@@ -1,0 +1,124 @@
+{-# LANGUAGE CPP #-}
+-- -*-haskell-*-
+--  GIMP Toolkit (GTK) Widgets StackSwitcher
+--
+--  Author : Moritz Schulte
+--
+--  Created: 27 April 2016
+--
+--  Copyright (C) 2016 Moritz Schulte
+--
+--  This library is free software; you can redistribute it and/or
+--  modify it under the terms of the GNU Lesser General Public
+--  License as published by the Free Software Foundation; either
+--  version 2.1 of the License, or (at your option) any later version.
+--
+--  This library is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+--  Lesser General Public License for more details.
+--
+-- |
+-- Maintainer  : gtk2hs-users@lists.sourceforge.net
+-- Stability   : provisional
+-- Portability : portable (depends on GHC)
+--
+-- A widget which controls the alignment and size of its child
+--
+module Graphics.UI.Gtk.Layout.StackSwitcher (
+-- * Detail
+--
+-- [...]
+--
+-- * Class Hierarchy
+-- |
+-- @
+-- |  'GObject'
+-- |   +----'Object'
+-- |         +----'Widget'
+-- |               +----'Container'
+-- |                     +----'Box'
+-- |                           +----'StackSwitcher'
+-- @
+
+-- * Types
+#if GTK_CHECK_VERSION(3,10,0)
+    StackSwitcher
+  , castToStackSwitcher
+  , gTypeStackSwitcher
+  , toStackSwitcher
+
+-- * Constructors
+  , stackSwitcherNew
+
+-- * Methods
+  , stackSwitcherSetStack
+  , stackSwitcherGetStack
+
+-- * Attributes
+  , stackSwitcherIconSize
+  , stackSwitcherStack
+#endif
+) where
+
+#if GTK_CHECK_VERSION(3,10,0)
+
+import Control.Monad    (liftM)
+
+import System.Glib.FFI
+import System.Glib.Attributes
+import System.Glib.Properties
+import Graphics.UI.Gtk.Abstract.Object  (makeNewObject)
+{#import Graphics.UI.Gtk.Types#}
+
+{# context lib="gtk" prefix="gtk" #}
+
+--------------------
+-- Constructors
+
+-- | Creates a new 'StackSwitcher'.
+--
+stackSwitcherNew :: IO StackSwitcher
+stackSwitcherNew =
+  makeNewObject mkStackSwitcher $
+  liftM (castPtr :: Ptr Widget -> Ptr StackSwitcher) $
+  {# call unsafe stack_switcher_new #}
+
+--------------------
+-- Methods
+
+-- | Sets the stack to control.
+stackSwitcherSetStack :: (StackSwitcherClass self, StackClass stack) => self
+ -> stack
+ -> IO ()
+stackSwitcherSetStack self stack =
+  {# call stack_switcher_set_stack #}
+    (toStackSwitcher self)
+    (toStack stack)
+
+-- | Retrieves the stack.
+stackSwitcherGetStack :: StackSwitcherClass self => self
+ -> IO (Maybe Stack)
+stackSwitcherGetStack self =
+  maybeNull (makeNewObject mkStack) $
+  {# call stack_switcher_get_stack #}
+    (toStackSwitcher self)
+
+--------------------
+-- Attributes
+
+-- | Use the "icon-size" property to change the size of the image
+-- displayed when a GtkStackSwitcher is displaying icons.
+--
+-- Default value: @1@
+--
+stackSwitcherIconSize :: StackSwitcherClass self => Attr self Int
+stackSwitcherIconSize = newAttrFromIntProperty "icon-size"
+
+-- | The 'Stack' controlled by this 'StackSwitcher'.
+--
+stackSwitcherStack :: (StackSwitcherClass self, StackClass stack) =>
+  ReadWriteAttr self (Maybe Stack) (Maybe stack)
+stackSwitcherStack = newAttrFromMaybeObjectProperty "stack" gTypeContainer
+
+#endif

--- a/gtk/demo/stack/Makefile
+++ b/gtk/demo/stack/Makefile
@@ -1,0 +1,11 @@
+
+PROG  = stack
+SOURCES = Stack.hs
+
+$(PROG) : $(SOURCES)
+	$(HC) --make $< -o $@ $(HCFLAGS)
+
+clean:
+	rm -f $(SOURCES:.hs=.hi) $(SOURCES:.hs=.o) $(PROG)
+
+HC=ghc

--- a/gtk/demo/stack/Stack.hs
+++ b/gtk/demo/stack/Stack.hs
@@ -1,0 +1,48 @@
+-- A simple program to demonstrate Gtk2Hs.
+module Main (Main.main) where
+
+import Graphics.UI.Gtk
+
+main :: IO ()
+main = do
+  initGUI
+  -- Create a new window
+  window <- windowNew
+  -- Here we connect the "destroy" event to a signal handler.
+  -- This event occurs when we call widgetDestroy on the window
+  -- or if the user closes the window.
+  on window objectDestroy mainQuit
+  -- Sets the border width and tile of the window. Note that border width
+  -- attribute is in 'Container' from which 'Window' is derived.
+  set window [ containerBorderWidth := 10, windowTitle := "Stack" ]
+  -- Creates a new button with the label "Hello World".
+
+  vBox <- vBoxNew False 0
+  
+  checkbutton <- checkButtonNewWithLabel "Click me!"
+  -- stackSwitcher <- labelNew (Just "foo")
+  -- stack <- labelNew (Just "bar")
+  stack <- stackNew
+  stackSetTransitionType stack StackTransitionTypeSlideLeftRight
+  stackSetTransitionDuration stack 1000
+  stackAddTitled stack checkbutton "check" "Check Button"
+  label <- labelNew (Nothing :: Maybe String)
+  labelSetMarkup label "<big>A fancy label</big>"
+  stackAddTitled stack label "label" "A label"
+  stackSwitcher <- stackSwitcherNew
+  set stackSwitcher [ stackSwitcherStack := Just stack ]
+  -- stackSwitcherSetStack stackSwitcher stack
+  --set stackSwitcher [ stackSwitcherStack := (Nothing :: Maybe Stack) ]
+
+  boxPackStart vBox stackSwitcher PackNatural 0
+  boxPackStart vBox stack PackNatural 0
+
+  set window [ containerChild := vBox ]
+
+  -- The final step is to display this newly created widget. Note that this
+  -- also allocates the right amount of space to the windows and the button.
+  widgetShowAll window
+  -- All Gtk+ applications must have a main loop. Control ends here
+  -- and waits for an event to occur (like a key press or mouse event).
+  -- This function returns if the program should finish.
+  mainGUI

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -234,6 +234,8 @@ Library
           Graphics.UI.Gtk.Layout.VBox
           Graphics.UI.Gtk.Layout.VButtonBox
           Graphics.UI.Gtk.Layout.VPaned
+          Graphics.UI.Gtk.Layout.Stack
+          Graphics.UI.Gtk.Layout.StackSwitcher
           Graphics.UI.Gtk.MenuComboToolbar.CheckMenuItem
           Graphics.UI.Gtk.MenuComboToolbar.ComboBox
           Graphics.UI.Gtk.MenuComboToolbar.ImageMenuItem

--- a/gtk/hierarchy3.list
+++ b/gtk/hierarchy3.list
@@ -72,6 +72,7 @@
                 GtkContainer
 				    GtkToolPalette		
 				    GtkToolItemGroup	
+                    GtkStack                            if gtk-3.10
                     WebKitWebView as WebView, webkit_web_view_get_type            if webkit
                     GtkBin
                         GtkAlignment
@@ -116,6 +117,7 @@
 			    GtkSeparatorToolItem	
 			GtkMozEmbed		if mozembed
 			VteTerminal as Terminal if vte
+                        GtkStackSwitcher        if gtk-3.10
                     GtkBox
                         GtkButtonBox
                             GtkHButtonBox

--- a/tools/hierarchyGen/hierarchy.list
+++ b/tools/hierarchyGen/hierarchy.list
@@ -103,6 +103,7 @@
 			    GtkSeparatorToolItem	if gtk-2.4
 			GtkMozEmbed		if mozembed
 			VteTerminal as Terminal if vte
+                        GtkStack
                     GtkBox
                         GtkButtonBox
                             GtkHButtonBox
@@ -136,6 +137,7 @@
                         GtkSourceView	if gtksourceview2
                     GtkToolbar
                     GtkTreeView
+                    GtkStack
                 GtkCalendar
                 GtkCellView		if gtk-2.6
 		GtkDrawingArea


### PR DESCRIPTION
gtk/Graphics/UI/Gtk.chs: Re-export Graphics.UI.Gtk.Layout.Stack and
Graphics.UI.Gtk.Layout.StackSwitcher.

gtk/Graphics/UI/Gtk/General/Enums.csh: Define and export
StackTransitionType.

gtk/Graphics/UI/Gtk/Layout/Stack.chs: New file, implementing Stack
interface.

gtk/Graphics/UI/Gtk/Layout/StackSwitcher.chs: New file, implementing
StackSwitcher interface.

gtk/gtk3.cabal: Expose modules Graphics.UI.Gtk.Layout.Stack and
Graphics.UI.Gtk.Layout.StackSwitcher.

gtk/hierarchy3.list: Added GtkStack and GtkStackSwitcher.
tools/hierarchyGen/hierarchy.list: dito.

gtk/demo/stack: Added small demo for Stack and StackSwitcher.