### PR TITLE
Remove ContextId related inconsistency in the Statusbar API

### DIFF
--- a/gtk/Graphics/UI/Gtk/Display/Statusbar.chs
+++ b/gtk/Graphics/UI/Gtk/Display/Statusbar.chs
@@ -234,12 +234,12 @@ statusbarGetMessageArea self =
 -- * Available since Gtk+ version 2.22
 --
 statusbarRemoveAll :: StatusbarClass self => self
-                   -> Int -- ^ @contextId@ a context identifier
+                   -> ContextId -- ^ @contextId@ a context identifier
                    -> IO ()
 statusbarRemoveAll self contextId =
   {#call gtk_statusbar_remove_all #}
     (toStatusbar self)
-    (fromIntegral contextId)
+    contextId
 #endif
 
 --------------------


### PR DESCRIPTION
gtk/Graphics/UI/Gtk/Display/Statusbar.chs: Make statusbarRemoveAll use
ContextId type instead of Int; just like statusbarPush, statusbarPop,
etc.