### PR TITLE
make sure ListStore implements TreeModelIface correctly

### DIFF
--- a/gtk/Graphics/UI/Gtk/ModelView/ListStore.hs
+++ b/gtk/Graphics/UI/Gtk/ModelView/ListStore.hs
@@ -98,8 +98,9 @@ listStoreNewDND xs mDSource mDDest = do
   customStoreNew rows ListStore TreeModelIface {
       treeModelIfaceGetFlags      = return [TreeModelListOnly],
       treeModelIfaceGetIter       = \[n] -> readIORef rows >>= \rows ->
-                                     return (if Seq.null rows then Nothing else
-                                             Just (TreeIter 0 (fromIntegral n) 0 0)),
+                                     return (if inRange (0, Seq.length rows - 1) n
+                                                 then Just (TreeIter 0 (fromIntegral n) 0 0)
+                                                 else Nothing),
       treeModelIfaceGetPath       = \(TreeIter _ n _ _) -> return [fromIntegral n],
       treeModelIfaceGetRow        = \(TreeIter _ n _ _) ->
                                  readIORef rows >>= \rows ->
@@ -112,7 +113,11 @@ listStoreNewDND xs mDSource mDDest = do
                                  if inRange (0, Seq.length rows - 1) (fromIntegral (n+1))
                                    then return (Just (TreeIter 0 (n+1) 0 0))
                                    else return Nothing,
-      treeModelIfaceIterChildren  = \_ -> return Nothing,
+      treeModelIfaceIterChildren  = \index -> readIORef rows >>= \rows ->
+                                         case index of
+                                             Nothing | not (Seq.null rows) ->
+                                                        return (Just (TreeIter 0 0 0 0))
+                                             _       -> return Nothing,
       treeModelIfaceIterHasChild  = \_ -> return False,
       treeModelIfaceIterNChildren = \index -> readIORef rows >>= \rows ->
                                            case index of


### PR DESCRIPTION
The current implementation of the TreeModelIface interface by ListStore
is not 100% correct. This causes a problem with combo boxes not being
rendered correctly when they don't have an Entry box. This only occurs
under GTK 3.

The main issue is with treeModelIfaceIterChildren: this function is
sometimes called with Nothing as its argument by GTK, even for a flat
list store. That happens when GTK is trying to obtain an iterator
pointing to the first element of the list. The current implementation
returns unconditionally Nothing, which is wrong.

There is also a similar issue with treeModelIfaceGetIter which can
return an out-of-bounds iterator and causes GTK 3 to display an
additional blank element in combo boxes.