### PR TITLE
Export classes from EventM module

### DIFF
--- a/gtk/Graphics/UI/Gtk/Gdk/EventM.hsc
+++ b/gtk/Graphics/UI/Gtk/Gdk/EventM.hsc
@@ -98,6 +98,13 @@ module Graphics.UI.Gtk.Gdk.EventM (
 --   you can (and usually have to) use @liftIO@ to execute @IO@ functions.
 --
 
+-- * Classes
+
+  HasCoordinates,
+  HasRootCoordinates,
+  HasModifier,
+  HasTime,
+
 -- * Event monad and type tags
   EventM,
   EAny,


### PR DESCRIPTION
Was there an intentional reason why these classes are hidden?