### PR TITLE
Allow building with directory-1.3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.2
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
   allow_failures:

--- a/tools/gtk2hs-buildtools.cabal
+++ b/tools/gtk2hs-buildtools.cabal
@@ -38,11 +38,11 @@ Flag ClosureSignals
 
 Library
         build-depends:   base >= 4 && < 5,
-                         process, directory, array, containers, pretty,
+                         process, array, pretty,
                          filepath, random,
                          Cabal >= 1.24.0.0 && < 1.25,
                          filepath >= 1.3.0.0 && < 1.5,
-                         directory >= 1.2.0.0 && < 1.3,
+                         directory >= 1.2.0.0 && < 1.4,
                          containers >= 0.5.5.1 && < 0.6
         if impl(ghc >= 7.7)
           build-depends: hashtables


### PR DESCRIPTION
GHC 8.0.2 ships with `directory-1.3.0.0`, for which `gtk2hs-buildtools`' upper version bounds (`< 1.3`) are too tight. The only API-breaking change in `directory-1.3.0.0` involves `canonicalizePath`, which `gtk2hs-buildtools` doesn't use, so this bound can be relaxed.

I also deleted some redundant entries in `build-depends` while I was in town.

Fixes #193.