### PR TITLE
treat freebsd the same as darwin

### DIFF
--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -18,8 +18,8 @@ Category:       Graphics
 Tested-With:    GHC == 7.0.4, GHC == 7.2.2, GHC == 7.4.1
 extra-source-files: cairo-gtk2hs.h
 
-Data-Dir:		demo
-Data-Files:		cairo-clock-icon.png
+Data-Dir:       demo
+Data-Files:     cairo-clock-icon.png
                 gtk2/CairoGhci.hs
                 gtk2/Clock.hs
                 gtk2/Drawing2.hs
@@ -36,7 +36,7 @@ Data-Files:		cairo-clock-icon.png
                 gtk3/Makefile
                 gtk3/StarAndRing.hs
                 gtk3/Text.hs
-				
+
 Source-Repository head
   type:         git
   location:     https://github.com/gtk2hs/gtk2hs
@@ -44,13 +44,13 @@ Source-Repository head
 
 Flag cairo_pdf
   Description: Build the PDF backend of Cairo.
-  
+
 Flag cairo_ps
   Description: Build the PostScript backend of Cairo.
 
 Flag cairo_svg
   Description: Build the Scalable Vector Graphics (SVG) backend of Cairo.
-  
+
 custom-setup
   setup-depends: base >= 4.6,
                  Cabal >= 1.24 && < 1.25,
@@ -64,8 +64,8 @@ Library
         exposed-modules:  Graphics.Rendering.Cairo
                           Graphics.Rendering.Cairo.Matrix
                           Graphics.Rendering.Cairo.Types
-			  -- this module is only meant to be used by other
-			  -- modules implementing a Cairo interface
+                          -- this module is only meant to be used by other
+                          -- modules implementing a Cairo interface
                           Graphics.Rendering.Cairo.Internal
         other-modules:
                           Graphics.Rendering.Cairo.Internal.Drawing.Cairo
@@ -93,5 +93,5 @@ Library
           pkgconfig-depends: cairo-ps
         if flag(cairo_svg)
           pkgconfig-depends: cairo-svg
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=

--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -82,7 +82,7 @@ Library
         default-extensions: ForeignFunctionInterface
 		
         cpp-options:    -U__BLOCKS__ -Ubool
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
 
         x-Signals-File:  System/GIO/Signals.chs

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -42,7 +42,7 @@ Library
                         text >= 1.0.0.0 && < 1.3,
                         containers
         cpp-options:    -U__BLOCKS__
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
         if flag(closure_signals)
           cpp-options:  -DUSE_GCLOSURE_SIGNALS_IMPL

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -382,7 +382,7 @@ Library
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
         cpp-options: -U__BLOCKS__
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
         if !flag(deprecated)
           cpp-options:  -DDISABLE_DEPRECATED

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -372,7 +372,7 @@ Library
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
         cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
         if os(windows)
           cpp-options:    -DWIN32 -fno-exceptions

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -79,14 +79,14 @@ Library
         includes:       hspango.h
         include-dirs:   .
         cpp-options:    -U__BLOCKS__
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
         if os(windows)
           cpp-options: -D__USE_MINGW_ANSI_STDIO=1
         -- Pango 1.26 has a mysterious bug that makes it go into an infinite
         -- loop. Don't allow the user to build against this version. (Omit the
         -- >= 1.0 constraint in this case since Cabal 1.6 can't parse it.)
-        if os(darwin)
+        if os(darwin) || os(freebsd)
           pkgconfig-depends: pango < 1.26.0 || > 1.26.2
         else
           pkgconfig-depends: pango >= 1.0


### PR DESCRIPTION
I also did cleanup on some rouge whitespace (+ awkward tabs->spaces).

This patch allows me to build on FreeBSD-12 via TrueOS.