### PR TITLE
Revive region (gdk_cairo_region)

### DIFF
--- a/gtk/Graphics/UI/Gtk/Cairo.chs
+++ b/gtk/Graphics/UI/Gtk/Cairo.chs
@@ -171,16 +171,12 @@ rectangle rect = Render $ do
       cr
       (castPtr rectPtr)
 
-#if GTK_MAJOR_VERSION < 3
 -- | Adds the given region to the current path of the 'Render' context.
---
--- Removed in Gtk3.
 region :: Region -> Render ()
 region region = Render $ do
   cr <- ask
   liftIO $ {# call unsafe gdk_cairo_region #}
     cr
     region
-#endif
 
 #endif


### PR DESCRIPTION
This function has been dropped in the gtk3 package but `gdk_cairo_region` does still exist upstream: https://developer.gnome.org/gdk3/stable/gdk3-Cairo-Interaction.html#gdk-cairo-region.

Why has it been removed and does it make sense to revive it?