### PR TITLE
cabal 2.1 compat (again):  rewriteFile is back to accepting two arguments

### DIFF
--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -342,11 +342,7 @@ genSynthezisedFiles verb pd lbi = do
       genFile :: ([String] -> IO String) -> [ProgArg] -> FilePath -> IO ()
       genFile prog args outFile = do
          res <- prog args
-#if MIN_VERSION_Cabal(2,1,0)
-         rewriteFile silent outFile res
-#else
          rewriteFile outFile res
-#endif
 
   forM_ (filter (\(tag,_) -> "x-types-" `isPrefixOf` tag && "file" `isSuffixOf` tag) xList) $
     \(fileTag, f) -> do


### PR DESCRIPTION
Cabal commit 5797013fa552268e726d19d4c4d326621ecd833c, as shipped with GHC 8.4-alpha2
restores the old rewriteFile, that accepts two arguments.