### PR TITLE
bump Cabal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=2.0 GHCVER=8.2.2
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.9,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=2.2 GHCVER=8.4.1
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1,happy-1.19.5,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1,happy-1.19.9,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
-      addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.9,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
   allow_failures:
     - env: CABALVER=head GHCVER=head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ matrix:
     - env: CABALVER=head GHCVER=head
 
 before_install:
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH:$HOME/.cabal/bin
+  - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH
 
 install:
   - cabal --version
-  - ghc --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - cabal update
   - cabal install Cabal

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - cabal update
-  - printf 'repository hackage.haskell.org\nurl: http://hackage.haskell.org/' >> $HOME/.cabal/config
   - cabal install Cabal
   - cabal install haddock
   - haddock -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.1
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1,happy-1.19.5,alex-3.2.4,libgtk2.0-dev,libgtk-3-dev], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4,libgtk2.0-dev,libgtk-3-dev],  sources: [hvr-ghc]}}
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - cabal update
+  - printf 'repository hackage.haskell.org\nurl: http://hackage.haskell.org/' >> $HOME/.cabal/config
   - cabal install Cabal
   - cabal install haddock
   - haddock -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,11 @@ matrix:
     - env: CABALVER=head GHCVER=head
 
 before_install:
-  - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH:$HOME/.cabal/bin
 
 install:
   - cabal --version
+  - ghc --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - cabal update
   - cabal install Cabal

--- a/cairo/Graphics/Rendering/Cairo/Internal/Utilities.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Utilities.chs
@@ -16,7 +16,7 @@ module Graphics.Rendering.Cairo.Internal.Utilities where
 
 {#import Graphics.Rendering.Cairo.Types#}
 
-import Foreign
+import Foreign hiding (unsafePerformIO)
 import Foreign.C
 -- TODO work around cpphs https://ghc.haskell.org/trac/ghc/ticket/13553
 #if __GLASGOW_HASKELL__ >= 707 || __GLASGOW_HASKELL__ == 0

--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -53,7 +53,7 @@ Flag cairo_svg
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.1,
+                 Cabal >= 1.24 && < 2.3,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library

--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -19,7 +19,7 @@ Description:    GIO is striving to provide a modern, easy-to-use VFS API that si
 Category:       System
 Tested-With:    GHC == 7.0.4, GHC == 7.2.2, GHC == 7.4.1
 Extra-Source-Files: marshal.list
-					hierarchy.list
+                    hierarchy.list
 
 x-Types-File:      System/GIO/Types.chs
 x-Types-ModName:   System.GIO.Types
@@ -40,7 +40,7 @@ Source-Repository head
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.1,
+                 Cabal >= 1.24 && < 2.3,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -32,7 +32,7 @@ Flag closure_signals
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.1,
+                 Cabal >= 1.24 && < 2.3,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -130,7 +130,7 @@ Flag fmode-binary
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.1,
+                 Cabal >= 1.24 && < 2.3,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 
 Library

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -40,7 +40,7 @@ Flag new-exception
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 2.1,
+                 Cabal >= 1.24 && < 2.3,
                  filepath >= 1.3 && < 1.5,
                  gtk2hs-buildtools >= 0.13.2.0 && < 0.14
 


### PR DESCRIPTION
This would bump the `Cabal` version to allow it to build with ghc-8.4.1, which would unblock ghc-8.4.1 support for `threadscope`.