### PR TITLE
added support for copyPath, copyPathFlat, and appendPath (demo included)

### DIFF
--- a/cairo/Graphics/Rendering/Cairo.hs
+++ b/cairo/Graphics/Rendering/Cairo.hs
@@ -127,6 +127,9 @@ module Graphics.Rendering.Cairo (
   , relCurveTo
   , relLineTo
   , relMoveTo
+  , copyPath
+  , copyPathFlat
+  , appendPath
 
   -- ** Patterns
   , withRGBPattern
@@ -300,6 +303,7 @@ module Graphics.Rendering.Cairo (
   , HintMetrics(..)
   , FontOptions
   , Path
+  , PathElement(..)
 #if CAIRO_CHECK_VERSION(1,10,0)
   , RectangleInt(..)
   , RegionOverlap(..)
@@ -996,6 +1000,29 @@ relMoveTo ::
   -> Double -- ^ @dy@ - the Y offset
   -> Render ()
 relMoveTo = liftRender2 Internal.relMoveTo
+
+
+-- | Creates a copy of the current path and returns it to the user.
+copyPath :: Render Path
+copyPath = liftRender0 Internal.copyPath
+
+
+-- | Gets a flattened copy of the current path and returns it to the user.
+--
+-- This function is like copyPath except that any curves in the path will be
+-- approximated with piecewise-linear approximations, accurate to within the current tolerance value.
+-- That is, any path elements created by curveTo or relCurveTo will be replaced by a series of lineTo elements.
+copyPathFlat :: Render Path
+copyPathFlat = liftRender0 Internal.copyPathFlat
+
+
+-- | Append the path onto the current path.
+--
+-- The path may be either the return value from copyPath or copyPathFlat or it may be constructed manually.
+appendPath :: Path      -- ^ the path to append
+           -> Render ()
+appendPath = liftRender1 Internal.appendPath
+
 
 
 -- | Creates a new 'Pattern' corresponding to an opaque color. The color

--- a/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Paths.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Paths.chs
@@ -17,11 +17,16 @@ module Graphics.Rendering.Cairo.Internal.Drawing.Paths where
 
 import Foreign
 import Foreign.C
-import Data.Text
+import Foreign.Marshal.Alloc (mallocBytes,finalizerFree)
 
 import Graphics.Rendering.Cairo.Internal.Utilities (CairoString(..))
 
 {#context lib="cairo" prefix="cairo"#}
+
+{#pointer *path_t as CPath newtype#}
+unPath :: CPath -> Ptr CPath
+unPath (CPath p) = p
+
 
 {#fun get_current_point as getCurrentPoint { unCairo `Cairo', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `()'#}
 {#fun new_path          as newPath         { unCairo `Cairo' } -> `()'#}
@@ -40,3 +45,165 @@ textPath c string =
 {#fun rel_curve_to      as relCurveTo      { unCairo `Cairo', `Double', `Double', `Double', `Double', `Double', `Double' } -> `()'#}
 {#fun rel_line_to       as relLineTo       { unCairo `Cairo', `Double', `Double' } -> `()'#}
 {#fun rel_move_to       as relMoveTo       { unCairo `Cairo', `Double', `Double' } -> `()'#}
+{#fun copy_path         as copyPathC       { unCairo `Cairo' } -> `CPath' CPath #}
+{#fun copy_path_flat    as copyPathFlatC   { unCairo `Cairo' } -> `CPath' CPath #}
+{#fun append_path       as appendPathC     { unCairo `Cairo', unPath `CPath' } -> `()' #}
+{#fun path_destroy      as pathDestroy     { unPath `CPath' } -> `()' #}
+
+
+{#enum path_data_type_t as PathDataRecordType {underscoreToCase} deriving(Eq,Show)#}
+
+data PathDataRecord
+ = PathHeaderRecord PathDataRecordType Int
+ | PathPointRecord Double Double
+ deriving (Eq,Show)
+
+
+copyPath :: Cairo -> IO [PathElement]
+copyPath ctx = do
+   p <- copyPathC ctx
+   xs <- pathToList p
+   pathDestroy p
+   return xs
+
+
+copyPathFlat :: Cairo -> IO [PathElement]
+copyPathFlat ctx = do
+   p <- copyPathFlatC ctx
+   xs <- pathToList p
+   pathDestroy p
+   return xs
+
+
+appendPath :: Cairo -> [PathElement] -> IO ()
+appendPath ctx es = do
+   path <- mkPathPtr es
+   appendPathC ctx path
+   deallocPath path
+
+
+pathToList :: CPath -> IO [PathElement]
+pathToList p  =  pathToList' <$> pathToList'' p
+
+
+
+pathToList' :: [PathDataRecord] -> [PathElement]
+pathToList' [] = []
+pathToList' ((PathHeaderRecord htype hlen):rs)
+   | hlen >= 1 = let (mine,rest) = splitAt (hlen-1) rs
+                 in  (consElem htype mine) : pathToList' rest
+   | otherwise = error "invalid path data (invalid header length)"
+pathToList' _ = error "invalid path data (expected header record)"
+
+
+
+pathToList'' :: CPath -> IO [PathDataRecord]
+pathToList'' (CPath p) = do
+      numdata <- {#get path_t->num_data #} p
+      dptr    <- {#get path_t->data#} p
+      getPathData 0 (cIntConv numdata) (castPtr dptr)
+
+  where  size = {#sizeof path_data_t#}
+         getPathData :: Int -> Int -> Ptr PathDataRecord -> IO [PathDataRecord]
+         getPathData currpos numdata dptr
+            | currpos < numdata = do
+               let dptr' = dptr `plusPtr` (size*currpos)
+               h@(PathHeaderRecord _ hlen) <- peekHeader dptr'
+               ds <- peekPoints dptr' hlen
+               rest <- getPathData (currpos+hlen) numdata dptr
+               return$ h:(ds++rest)
+            | otherwise = return []
+
+         peekHeader :: Ptr PathDataRecord -> IO PathDataRecord
+         peekHeader p = do
+            -- the more intuitive statement
+            --     htype <- {#get path_data_t->header.type #} p
+            -- generates an error
+            -- "CHS module contains errors: The phrase `type' is not allowed here."
+            htype <- peekByteOff p 0 :: IO CInt
+            hlen <- {#get path_data_t->header.length #} p
+            return$ PathHeaderRecord (cToEnum htype) (cIntConv hlen)
+
+         peekPoint :: Ptr PathDataRecord -> IO PathDataRecord
+         peekPoint p = do
+            x <- {#get path_data_t->point.x #} p
+            y <- {#get path_data_t->point.y #} p
+            return$ PathPointRecord (cFloatConv x) (cFloatConv y)
+
+         peekPoints :: Ptr PathDataRecord -> Int -> IO [PathDataRecord]
+         peekPoints p n = mapM (\i -> peekPoint (p `plusPtr` (size*i))) [1..(n-1)]
+
+
+
+getPts = \(PathPointRecord x y) -> (x,y)
+
+
+pokeRecord :: Ptr PathDataRecord -> PathDataRecord -> IO ()
+pokeRecord ptr (PathHeaderRecord htype hlen) = do
+   pokeByteOff ptr 0 (cFromEnum htype :: CInt)  -- the member named 'type' of the header is misunderstood by c2hs (see above)
+   {#set path_data_t->header.length #} ptr (cIntConv hlen)
+
+pokeRecord ptr (PathPointRecord x y) = do
+   {#set path_data_t->point.x #} ptr (cFloatConv x)
+   {#set path_data_t->point.y #} ptr (cFloatConv y)
+
+
+
+
+
+consElem :: PathDataRecordType -> [PathDataRecord] -> PathElement
+consElem PathMoveTo ps
+   | length ps < 1   = error "invalid path data (not enough points)"
+   | otherwise       = uncurry MoveTo $ getPts (ps!!0)
+consElem PathLineTo ps
+   | length ps < 1   = error "invalid path data (not enough points)"
+   | otherwise       = uncurry LineTo $ getPts (ps!!0)
+consElem PathCurveTo ps
+   | length ps < 3   = error "invalid path data (not enough points)"
+   | otherwise       = let ps' = map getPts (take 3 ps)
+                       in uncurry (uncurry (uncurry CurveTo (ps'!!0)) (ps'!!1)) (ps'!!2)
+consElem PathClosePath ps = ClosePath
+
+
+consRecs :: PathElement -> [PathDataRecord]
+consRecs (MoveTo x y) =
+   [ PathHeaderRecord PathMoveTo 2, PathPointRecord x y]
+consRecs (LineTo x y) =
+   [ PathHeaderRecord PathLineTo 2, PathPointRecord x y]
+consRecs (CurveTo x₀ y₀ x₁ y₁ x₂ y₂) =
+   [ PathHeaderRecord PathCurveTo 4
+   , PathPointRecord x₀ y₀
+   , PathPointRecord x₁ y₁
+   , PathPointRecord x₂ y₂
+   ]
+consRecs ClosePath = [PathHeaderRecord PathClosePath 1]
+
+
+
+mkPathPtr :: [PathElement] -> IO CPath
+mkPathPtr es = do
+   (dptr,numdata) <- mkDataPtr es
+   ptr <- mallocBytes {#sizeof path_t#}
+   {#set path_t->status #} ptr (cFromEnum StatusSuccess)
+   {#set path_t->data #} ptr (castPtr dptr)
+   {#set path_t->num_data #} ptr (cIntConv numdata)
+   return (CPath ptr)
+
+
+
+mkDataPtr :: [PathElement] -> IO (Ptr PathDataRecord, Int)
+mkDataPtr es = do
+   let rs = concatMap consRecs es
+       len  = length rs
+       size = {#sizeof path_data_t#}
+   dptr <- mallocBytes (len*size) :: IO (Ptr PathDataRecord)
+   mapM_ (\(r,i) -> pokeRecord (dptr `plusPtr` (i*size)) r) (zip rs [0..])
+   return (dptr,len)
+
+
+deallocPath :: CPath -> IO ()
+deallocPath (CPath ptr) = do
+   dptr <- {#get path_t->data#} ptr
+   free dptr
+   free ptr
+

--- a/cairo/Graphics/Rendering/Cairo/Types.chs
+++ b/cairo/Graphics/Rendering/Cairo/Types.chs
@@ -39,7 +39,7 @@ module Graphics.Rendering.Cairo.Types (
   , HintStyle(..)
   , HintMetrics(..)
   , FontOptions(..), withFontOptions, mkFontOptions
-  , Path(..), unPath
+  , Path, PathElement(..)
 #if CAIRO_CHECK_VERSION(1,10,0)
   , RectangleInt(..)
   , RegionOverlap(..)
@@ -323,14 +323,11 @@ foreign import ccall unsafe "&cairo_font_options_destroy"
 --
 -- http://cairographics.org/manual/bindings-path.html
 --
--- {#enum path_data_type_t as PathDataType {underscoreToCase}#}
---
--- type Point = (Double, Double)
--- data PathData = PathMoveTo Point
---               | PathLineTo Point
---               | PathCurveTo Point Point Point
---               | PathClose
-
+data PathElement = MoveTo Double Double
+                 | LineTo Double Double
+                 | CurveTo Double Double Double Double Double Double
+                 | ClosePath
+   deriving (Eq, Read, Show)
 -- | A Cairo path.
 --
 -- * A path is a sequence of drawing operations that are accumulated until
@@ -338,8 +335,8 @@ foreign import ccall unsafe "&cairo_font_options_destroy"
 --   useful when drawing lines with special join styles and
 --   'Graphics.Rendering.Cairo.closePath'.
 --
-{#pointer *path_t as Path newtype#}
-unPath (Path x) = x
+type Path = [PathElement]
+
 
 #if CAIRO_CHECK_VERSION(1,10,0)
 

--- a/cairo/demo/gtk3/Makefile
+++ b/cairo/demo/gtk3/Makefile
@@ -1,6 +1,7 @@
 
-PROGS  = drawing drawing2 starandring text clock graph sdldrawing
-SOURCES = Drawing.hs Drawing2.hs StarAndRing.hs Text.hs Clock.hs Graph.hs CairoSDL.hs
+PROGS  = drawing drawing2 starandring text clock graph sdldrawing paths
+SOURCES = Drawing.hs Drawing2.hs StarAndRing.hs Text.hs Clock.hs Graph.hs CairoSDL.hs Paths.hs
+OUTPUT = paths.png
 
 all : $(PROGS)
 
@@ -25,9 +26,12 @@ graph : Graph.hs
 sdldrawing : CairoSDL.hs
 	$(HC_RULE)
 
+paths : Paths.hs
+	$(HC_RULE)
+
 HC_RULE = $(HC) --make $< -o $@ $(HCFLAGS)
 
 clean:
-	rm -f $(SOURCES:.hs=.hi) $(SOURCES:.hs=.o) $(PROGS)
+	rm -f $(SOURCES:.hs=.hi) $(SOURCES:.hs=.o) $(PROGS) $(OUTPUT)
 
 HC=ghc

--- a/cairo/demo/gtk3/Paths.hs
+++ b/cairo/demo/gtk3/Paths.hs
@@ -1,0 +1,258 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+
+module Main where
+
+import           Prelude.Unicode
+import           Control.Monad.Unicode
+
+import           Graphics.Rendering.Cairo
+import           Graphics.Rendering.Cairo.Matrix      ( Matrix(..) )
+import qualified Graphics.Rendering.Cairo.Matrix   as Matrix
+
+
+
+main =  islamicWindows =<< makeLattice
+
+
+makeLattice ∷ IO Surface
+makeLattice = do
+   let w    = 15
+       h    = w
+       a    = w/9.5
+       w2   = (w/2 - a)
+       h2   = (h/2 - a)
+       mx   = Matrix   0   1 (-1)  0    w 0
+       my   = Matrix   0 (-1)  1   0    0 h
+       mxy  = Matrix (-1)  0   0 (-1)   w h
+   surface ← createImageSurface FormatARGB32 (truncate w) (truncate h)
+   renderWith surface $ do
+      moveTo 0 h2
+      lineTo a h2
+      curveTo a (h2-a) (w2-a) a w2 a
+      lineTo w2 0
+      p ← copyPath
+      let xPath  = transformPath mx p
+          yPath  = transformPath my p
+          xyPath = transformPath mxy p
+      appendPath (move2line xPath)
+      appendPath (move2line xyPath)
+      appendPath (move2line yPath)
+      closePath
+      p' ← copyPath
+      liftIO ∘ putStrLn $ "Path:"
+      liftIO ∘ putStrLn $ unlines (map show p')    -- notice how copyPath adds a MoveTo to the end of the path
+      p'' ← copyPathFlat
+      liftIO ∘ putStrLn $ "\nFlattened Path:"
+      liftIO ∘ putStrLn $ unlines (map show p'')
+      setSourceRGB 1 0.8 0
+      setLineWidth 0.4
+      stroke
+   return surface
+
+
+islamicWindows ∷ Surface → IO ()
+islamicWindows bg = frameIt 640 640 "paths.png" $ do
+   setSourceRGB 0.2 0.2 0.2
+   paint
+
+   setSourceRGB 0 0 1
+   setLineWidth 5
+   rectangle 10 10 620 620
+   stroke
+
+   let w  = 100
+       h1 = 84
+       h2 = 54
+       x1 = w/6
+       y1 = h1 + 2⋅h2/3
+       x2 = w/4
+       y2 = h1 + h2/4
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   curveTo x1 y1 x2 y2 (w/2) (h1+h2)
+   curveTo (w-x2) y2 (w-x1) y1 w h1
+   lineTo w 0
+   closePath
+   p00 ← copyPath
+
+   let w  = 100
+       h1 = 108
+       h2 = 54
+       x1 = w/16
+       y1 = h1 + h2/2 - 1/17⋅h2
+       x2 = w/2 - w/11
+       y2 = h1 + 4/5⋅h2
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   curveTo x1 y1 x2 y2 (w/2) (h1+h2)
+   curveTo (w-x2) y2 (w-x1) y1 w h1
+   lineTo w 0
+   closePath
+   p10 ← copyPath
+
+   let w  = 65
+       h1 = 108
+       h2 = 64
+       x1 = -w/3
+       y1 = h1 + 9/16⋅h2
+       x2 = w/3
+       y2 = h1 + 4/5⋅h2
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   curveTo x1 y1 x2 y2 (w/2) (h1+h2)
+   curveTo (w-x2) y2 (w-x1) y1 w h1
+   lineTo w 0
+   closePath
+   p20 ← copyPath
+
+   let w  = 95
+       h1 = 108
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   arcNegative (w/2) h1 (w/2) π (2⋅π)
+   lineTo w 0
+   closePath
+   p01 ← copyPath
+
+   let w1 = 110
+       w2 = 15
+       h1 = 108
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   arcNegative (w1/2) h1 ((w1 - 2⋅w2)/2) π (2⋅π)
+   lineTo w1 h1
+   lineTo w1 0
+   closePath
+   p11 ← copyPath
+
+   let w1 = 90
+       w2 = 14
+       h1 = 95
+       r = w1/2
+       α  = acos $ (w1/2 - w2) / r
+       h2 = r ⋅ sin α
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   arcNegative (w1/2) (h1+h2) r (π+α) (-α)
+   lineTo w1 h1
+   lineTo w1 0
+   closePath
+   p21 ← copyPath
+
+   let w1 = 90
+       w2 = 19
+       h1 = 95
+       h2 = 75
+       x1 = -w/3
+       y1 = h1 + 9/16⋅h2
+       x2 = w/3
+       y2 = h1 + 4/5⋅h2
+   newPath
+   moveTo 0 0
+   lineTo 0 h1
+   lineTo w2 h1
+   curveTo x1 y1 x2 y2 (w1/2) (h1+h2)
+   curveTo (w1-x2) y2 (w1-x1) y1 (w1-w2) h1
+   lineTo w1 h1
+   lineTo w1 0
+   closePath
+   p02 ← copyPath
+
+   let w  = 95
+       h = 70
+   newPath
+   moveTo 0 0
+   lineTo 0 h
+   arcNegative (w/2) h (w/2) π (2⋅π)
+   lineTo w 0
+   arcNegative (w/2) 0 (w/2) 0 π
+   p12 ← copyPath
+
+   let w  = 100
+       h  = 70
+   newPath
+   moveTo 0 0
+   arc 0 (h/2) (h/2) (3/2⋅π) (π/2)
+   lineTo w h
+   arc w (h/2) (h/2) (π/2) (3/2⋅π)
+   closePath
+   p22 ← copyPath
+
+
+   identityMatrix
+
+   let mats =  [ Matrix 1 0 0 (-1) 60 210
+               , Matrix 1 0 0 (-1) 270 210
+               , Matrix 1 0 0 (-1) 480 210
+               , Matrix 1 0 0 (-1) 60 420
+               , Matrix 1 0 0 (-1) 270 420
+               , Matrix 1 0 0 (-1) 480 420
+               , Matrix 1 0 0 (-1) 60 620
+               , Matrix 1 0 0 (-1) 270 570
+               , Matrix 1 0 0 (-1) 480 580
+               ]
+
+   let paths = zipWith transformPath mats [p00,p10,p20,p01,p11,p21,p02,p12,p22]
+
+   newPath
+   mapM_ appendPath paths
+   clip
+   withPatternForSurface bg $ \bgPat → do
+      patternSetExtend bgPat ExtendRepeat
+      setSource bgPat
+   paint
+
+   setSourceRGB 0.8 0.8 0.8
+   setLineWidth 7
+   mapM_ (\p → newPath ≫ appendPath p ≫ stroke) paths
+--
+
+
+
+
+frameIt ∷ Double → Double → String → Render () → IO ()
+frameIt w h filename r =
+   renderToPNG filename (truncate w) (truncate h) $ do
+      rectangle 9.2 9.2 (w-18.4) (h-18.4)
+      p ← copyPath
+      clip
+      save
+      r
+      restore
+      appendPath p
+      setSourceRGBA 1 1 0 0.7
+      setLineWidth 5.0
+      stroke
+--
+
+
+renderToPNG filename w h renderer = do
+   surface ← createImageSurface FormatARGB32 w h
+   renderWith surface renderer
+   surfaceWriteToPNG surface filename
+--
+
+
+
+transformPath ∷ Matrix → Path → Path
+transformPath mat = map mapElem
+   where tm u v = Matrix.transformPoint mat (u,v)
+         mapElem ∷ PathElement → PathElement
+         mapElem (MoveTo x y)                  = uncurry MoveTo (tm x y)
+         mapElem (LineTo x y)                  = uncurry LineTo (tm x y)
+         mapElem (CurveTo x₁ y₁ x₂ y₂ x₃ y₃)   =
+            uncurry (uncurry (uncurry CurveTo (tm x₁ y₁)) (tm x₂ y₂)) (tm x₃ y₃)
+         mapElem ClosePath                     = ClosePath
+--
+
+move2line ∷ Path → Path
+move2line = map m2l
+   where m2l (MoveTo x y)  = uncurry LineTo (x,y)
+         m2l x             = x


### PR DESCRIPTION
Alters the Path type (previously an unused opaque type) to be a list of PathElement.
Now paths can be extracted from Cairo and manipulated as ordinary Haskell data.

See the demo (run 'make paths' under cairo/demo/gtk3/) for an example of transforming a path using a matrix.
The demo depends upon base-unicode-symbols.

