### PR TITLE
Mesh Pattern Support

### DIFF
--- a/cairo/Graphics/Rendering/Cairo.hs
+++ b/cairo/Graphics/Rendering/Cairo.hs
@@ -133,6 +133,10 @@ module Graphics.Rendering.Cairo (
   , pathExtents
 
   -- ** Patterns
+  , createRGBPattern
+  , createRGBAPattern
+  , createLinearPattern
+  , createRadialPattern
   , withRGBPattern
   , withRGBAPattern
   , withPatternForSurface
@@ -1035,6 +1039,60 @@ pathExtents :: Render (Double,Double,Double,Double)
 pathExtents = liftRender0 Internal.pathExtents
 
 
+
+
+-- | 
+--
+createRGBPattern ::
+      MonadIO m =>
+      Double      -- ^ @r@
+   -> Double      -- ^ @g@
+   -> Double      -- ^ @b@
+   -> m Pattern
+createRGBPattern r g b = liftIO$ Internal.patternCreateRGB r g b
+
+
+-- | 
+--
+createRGBAPattern ::
+      MonadIO m =>
+      Double      -- ^ @r@
+   -> Double      -- ^ @g@
+   -> Double      -- ^ @b@
+   -> Double      -- ^ @a@
+   -> m Pattern
+createRGBAPattern r g b a = liftIO$ Internal.patternCreateRGBA r g b a
+
+
+-- | 
+--
+createLinearPattern ::
+      MonadIO m =>
+      Double      -- ^ @x1@
+   -> Double      -- ^ @y1@
+   -> Double      -- ^ @x2@
+   -> Double      -- ^ @y2@
+   -> m Pattern
+createLinearPattern x1 y1 x2 y2 = liftIO$ Internal.patternCreateLinear x1 y1 x2 y2
+
+
+-- | 
+--
+createRadialPattern ::
+      MonadIO m =>
+      Double      -- ^ @x1@
+   -> Double      -- ^ @y1@
+   -> Double      -- ^ @r1@
+   -> Double      -- ^ @x2@
+   -> Double      -- ^ @y2@
+   -> Double      -- ^ @r2@
+   -> m Pattern
+createRadialPattern x1 y1 r1 x2 y2 r2 = liftIO$ Internal.patternCreateRadial x1 y1 r1 x2 y2 r2
+
+
+
+
+
 -- | Creates a new 'Pattern' corresponding to an opaque color. The color
 -- components are floating point numbers in the range 0 to 1. If the values
 -- passed in are outside that range, they will be clamped.
@@ -1286,10 +1344,10 @@ patternGetFilter p = liftIO $ Internal.patternGetFilter p
 -- for a more detailed explanation of their usage, as this library merely provides a wrapper
 -- around the underlying C API.
 --
-patternCreateMesh ::
+createMeshPattern ::
       MonadIO m =>
       m Pattern
-patternCreateMesh = liftIO$ Internal.patternCreateMesh
+createMeshPattern = liftIO$ Internal.patternCreateMesh
 
 
 -- | A convenience method that adds a patch to the mesh pattern in a single call.

--- a/cairo/Graphics/Rendering/Cairo.hs
+++ b/cairo/Graphics/Rendering/Cairo.hs
@@ -130,6 +130,7 @@ module Graphics.Rendering.Cairo (
   , copyPath
   , copyPathFlat
   , appendPath
+  , pathExtents
 
   -- ** Patterns
   , withRGBPattern
@@ -1028,6 +1029,10 @@ appendPath :: Path      -- ^ the path to append
            -> Render ()
 appendPath = liftRender1 Internal.appendPath
 
+
+
+pathExtents :: Render (Double,Double,Double,Double)
+pathExtents = liftRender0 Internal.pathExtents
 
 
 -- | Creates a new 'Pattern' corresponding to an opaque color. The color

--- a/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Cairo.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Cairo.chs
@@ -29,13 +29,13 @@ import Foreign.C
 {#fun get_target         as getTarget        { unCairo `Cairo' } -> `Surface' mkSurface*#}
 {#fun push_group              as ^           { unCairo `Cairo' } -> `()' #}
 {#fun push_group_with_content as ^           { unCairo `Cairo', cFromEnum `Content' } -> `()' #}
-{#fun pop_group               as ^           { unCairo `Cairo' } -> `Pattern' Pattern #}
+{#fun pop_group               as ^           { unCairo `Cairo' } -> `Pattern' mkPattern* #}
 {#fun pop_group_to_source     as ^           { unCairo `Cairo' } -> `()' #}
 {#fun set_source_rgb     as setSourceRGB     { unCairo `Cairo', `Double', `Double', `Double' } -> `()'#}
 {#fun set_source_rgba    as setSourceRGBA    { unCairo `Cairo', `Double', `Double', `Double', `Double' } -> `()'#}
-{#fun set_source         as setSource        { unCairo `Cairo', unPattern `Pattern' } -> `()'#}
+{#fun set_source         as setSource        { unCairo `Cairo', withPattern* `Pattern' } -> `()'#}
 {#fun set_source_surface as setSourceSurface { unCairo `Cairo', withSurface* `Surface', `Double', `Double' } -> `()'#}
-{#fun get_source         as getSource        { unCairo `Cairo' } -> `Pattern' Pattern#}
+{#fun get_source         as getSource        { unCairo `Cairo' } -> `Pattern' clonePattern* #}
 {#fun set_antialias      as setAntialias     { unCairo `Cairo', cFromEnum `Antialias' } -> `()'#}
 {#fun get_antialias      as getAntialias     { unCairo `Cairo' } -> `Antialias' cToEnum#}
 setDash context xs offset = withArrayLen (map (cFloatConv) xs) $ \len ptr ->
@@ -62,7 +62,7 @@ setDash context xs offset = withArrayLen (map (cFloatConv) xs) $ \len ptr ->
 {#fun fill_preserve      as fillPreserve     { unCairo `Cairo' } -> `()'#}
 {#fun fill_extents       as fillExtents      { unCairo `Cairo', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `()'#}
 {#fun in_fill            as inFill           { unCairo `Cairo', `Double', `Double' } -> `Bool' cToBool#}
-{#fun mask               as mask             { unCairo `Cairo', unPattern `Pattern' } -> `()'#}
+{#fun mask               as mask             { unCairo `Cairo', withPattern* `Pattern' } -> `()'#}
 {#fun mask_surface       as maskSurface      { unCairo `Cairo', withSurface* `Surface', `Double', `Double' } -> `()'#}
 {#fun paint              as paint            { unCairo `Cairo' } -> `()'#}
 {#fun paint_with_alpha   as paintWithAlpha   { unCairo `Cairo', `Double' } -> `()'#}

--- a/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Paths.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Paths.chs
@@ -49,7 +49,7 @@ textPath c string =
 {#fun copy_path_flat    as copyPathFlatC   { unCairo `Cairo' } -> `CPath' CPath #}
 {#fun append_path       as appendPathC     { unCairo `Cairo', unPath `CPath' } -> `()' #}
 {#fun path_destroy      as pathDestroy     { unPath `CPath' } -> `()' #}
-
+{#fun path_extents      as pathExtents     { unCairo `Cairo', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `()' #}
 
 {#enum path_data_type_t as PathDataRecordType {underscoreToCase} deriving(Eq,Show)#}
 

--- a/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Patterns.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Patterns.chs
@@ -14,25 +14,86 @@
 module Graphics.Rendering.Cairo.Internal.Drawing.Patterns where
 
 {#import Graphics.Rendering.Cairo.Types#}
+{#import Graphics.Rendering.Cairo.Internal.Drawing.Paths #} ( CPath(..), pathDestroy, pathToList )
+
 
 import Foreign
 import Foreign.C
 
 {#context lib="cairo" prefix="cairo"#}
 
-{#fun pattern_add_color_stop_rgb  as patternAddColorStopRGB  { unPattern `Pattern', `Double', `Double', `Double', `Double' } -> `()'#}
-{#fun pattern_add_color_stop_rgba as patternAddColorStopRGBA { unPattern `Pattern', `Double', `Double', `Double', `Double', `Double' } -> `()'#}
-{#fun pattern_create_rgb          as patternCreateRGB        { `Double', `Double', `Double' } -> `Pattern' Pattern#}
-{#fun pattern_create_rgba         as patternCreateRGBA       { `Double', `Double', `Double', `Double' } -> `Pattern' Pattern#}
-{#fun pattern_create_for_surface  as patternCreateForSurface { withSurface* `Surface' } -> `Pattern' Pattern#}
-{#fun pattern_create_linear       as patternCreateLinear     { `Double', `Double', `Double', `Double' } -> `Pattern' Pattern#}
-{#fun pattern_create_radial       as patternCreateRadial     { `Double', `Double', `Double', `Double', `Double', `Double' } -> `Pattern' Pattern#}
-{#fun pattern_destroy    as patternDestroy   { unPattern `Pattern' } -> `()'#}
-{#fun pattern_reference  as patternReference { unPattern `Pattern' } -> `Pattern' Pattern#}
-{#fun pattern_status     as patternStatus    { unPattern `Pattern' } -> `Status' cToEnum#}
-{#fun pattern_set_extend as patternSetExtend { unPattern `Pattern', cFromEnum `Extend' } -> `()'#}
-{#fun pattern_get_extend as patternGetExtend { unPattern `Pattern' } -> `Extend' cToEnum#}
-{#fun pattern_set_filter as patternSetFilter { unPattern `Pattern', cFromEnum `Filter' } -> `()'#}
-{#fun pattern_get_filter as patternGetFilter { unPattern `Pattern' } -> `Filter' cToEnum#}
-{#fun pattern_set_matrix as patternSetMatrix { unPattern `Pattern', `Matrix' } -> `()'#}
-{#fun pattern_get_matrix as patternGetMatrix { unPattern `Pattern', alloca- `Matrix' peek*} -> `()'#}
+{#fun pattern_create_rgb            as patternCreateRGB           { `Double', `Double', `Double' } -> `Pattern' mkPattern* #}
+{#fun pattern_create_rgba           as patternCreateRGBA          { `Double', `Double', `Double', `Double' } -> `Pattern' mkPattern* #}
+{#fun pattern_get_rgba              as patternGetRGBA             { withPattern* `Pattern', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `Status' cToEnum #}
+
+{#fun pattern_create_linear         as patternCreateLinear        { `Double', `Double', `Double', `Double' } -> `Pattern' mkPattern* #}
+{#fun pattern_create_radial         as patternCreateRadial        { `Double', `Double', `Double', `Double', `Double', `Double' } -> `Pattern' mkPattern* #}
+{#fun pattern_add_color_stop_rgb    as patternAddColorStopRGB     { withPattern* `Pattern', `Double', `Double', `Double', `Double' } -> `()' #}
+{#fun pattern_add_color_stop_rgba   as patternAddColorStopRGBA    { withPattern* `Pattern', `Double', `Double', `Double', `Double', `Double' } -> `()'#}
+{#fun pattern_get_color_stop_count  as patternGetColorStopCount   { withPattern* `Pattern', alloca- `Int' peekIntConv* } -> `Status' cToEnum #}
+{#fun pattern_get_color_stop_rgba   as patternGetColorStopRGBA    { withPattern* `Pattern', `Int', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*} -> `Status' cToEnum #}
+{#fun pattern_get_linear_points     as patternGetLinearPoints     { withPattern* `Pattern', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `Status' cToEnum #}
+{#fun pattern_get_radial_circles    as patternGetRadialCircles    { withPattern* `Pattern', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `Status' cToEnum #}
+
+{#fun pattern_create_for_surface    as patternCreateForSurface    { withSurface* `Surface' } -> `Pattern' mkPattern* #}
+
+{#fun pattern_status                as patternStatus              { withPattern* `Pattern' } -> `Status' cToEnum#}
+{#fun pattern_get_type              as patternGetType             { withPattern* `Pattern' } -> `PatternType' cToEnum #}
+
+{#fun pattern_set_extend            as patternSetExtend           { withPattern* `Pattern', cFromEnum `Extend' } -> `()'#}
+{#fun pattern_get_extend            as patternGetExtend           { withPattern* `Pattern' } -> `Extend' cToEnum#}
+{#fun pattern_set_filter            as patternSetFilter           { withPattern* `Pattern', cFromEnum `Filter' } -> `()'#}
+{#fun pattern_get_filter            as patternGetFilter           { withPattern* `Pattern' } -> `Filter' cToEnum#}
+{#fun pattern_set_matrix            as patternSetMatrix           { withPattern* `Pattern', `Matrix' } -> `()'#}
+{#fun pattern_get_matrix            as patternGetMatrix           { withPattern* `Pattern', alloca- `Matrix' peek*} -> `()'#}
+
+
+-- support for mesh patterns / tensor product patches
+#if CAIRO_CHECK_VERSION(1,12,0)
+{#fun pattern_create_mesh                 as patternCreateMesh             { } -> `Pattern' mkPattern* #}
+{#fun mesh_pattern_begin_patch            as meshPatternBeginPatch         { withPattern* `Pattern' } -> `()' #}
+{#fun mesh_pattern_end_patch              as meshPatternEndPatch           { withPattern* `Pattern' } -> `()' #}
+{#fun mesh_pattern_move_to                as meshPatternMoveTo             { withPattern* `Pattern', `Double', `Double' } -> `()' #}
+{#fun mesh_pattern_line_to                as meshPatternLineTo             { withPattern* `Pattern', `Double', `Double' } -> `()' #}
+{#fun mesh_pattern_curve_to               as meshPatternCurveTo            { withPattern* `Pattern', `Double', `Double', `Double', `Double', `Double', `Double' } -> `()' #}
+{#fun mesh_pattern_set_control_point      as meshPatternSetControlPoint    { withPattern* `Pattern', fromIntegral `Int', `Double', `Double' } -> `()' #}
+{#fun mesh_pattern_set_corner_color_rgb   as meshPatternSetCornerColorRGB  { withPattern* `Pattern', fromIntegral `Int', `Double', `Double', `Double' } -> `()' #}
+{#fun mesh_pattern_set_corner_color_rgba  as meshPatternSetCornerColorRGBA { withPattern* `Pattern', fromIntegral `Int', `Double', `Double', `Double', `Double'} -> `()' #}
+{#fun mesh_pattern_get_patch_count        as meshPatternGetPatchCount      { withPattern* `Pattern', alloca- `Int' peekIntConv* } -> `Status' cToEnum #}
+{#fun mesh_pattern_get_path               as meshPatternGetPathC           { withPattern* `Pattern', fromIntegral `Int' } -> `CPath' CPath #}
+{#fun mesh_pattern_get_control_point      as meshPatternGetControlPoint    { withPattern* `Pattern', fromIntegral `Int', fromIntegral `Int', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `Status' cToEnum #}
+{#fun mesh_pattern_get_corner_color_rgba  as meshPatternGetCornerColorRGBA { withPattern* `Pattern', fromIntegral `Int', fromIntegral `Int', alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv*, alloca- `Double' peekFloatConv* } -> `Status' cToEnum #}
+
+meshPatternGetPath :: Pattern -> Int -> IO [PathElement]
+meshPatternGetPath pat n = do
+   path <- meshPatternGetPathC pat n
+   xs   <- pathToList path
+   pathDestroy path
+   return xs
+
+convertPathElement :: Pattern -> PathElement -> IO ()
+convertPathElement pat (MoveTo x y)                = meshPatternMoveTo  pat x y
+convertPathElement pat (LineTo x y)                = meshPatternLineTo  pat x y
+convertPathElement pat (CurveTo x1 y1 x2 y2 x3 y3) = meshPatternCurveTo pat x1 y1 x2 y2 x3 y3
+convertPathElement  _  ClosePath                   = return ()
+
+meshPatternAddPatchRGB :: Pattern -> [PathElement] -> [(Double,Double)] -> [(Double,Double,Double)] -> IO Status
+meshPatternAddPatchRGB pat elems controlPoints colors = do
+   meshPatternBeginPatch pat
+   mapM_ (convertPathElement pat) (take 4 elems)
+   sequence_ $ zipWith (\(x,y) n -> meshPatternSetControlPoint pat n x y) (take 4 controlPoints) [0..3]
+   sequence_ $ zipWith (\(r,g,b) n -> meshPatternSetCornerColorRGB pat n r g b) (take 4 colors) [0..3]
+   meshPatternEndPatch pat
+   patternStatus pat
+
+meshPatternAddPatchRGBA :: Pattern -> [PathElement] -> [(Double,Double)] -> [(Double,Double,Double,Double)] -> IO Status
+meshPatternAddPatchRGBA pat elems controlPoints colors = do
+   meshPatternBeginPatch pat
+   mapM_ (convertPathElement pat) (take 4 elems)
+   sequence_ $ zipWith (\(x,y) n -> meshPatternSetControlPoint pat n x y) (take 4 controlPoints) [0..3]
+   sequence_ $ zipWith (\(r,g,b,a) n -> meshPatternSetCornerColorRGBA pat n r g b a) (take 4 colors) [0..3]
+   meshPatternEndPatch pat
+   patternStatus pat
+
+#endif
+

--- a/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Patterns.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Drawing/Patterns.chs
@@ -77,23 +77,5 @@ convertPathElement pat (LineTo x y)                = meshPatternLineTo  pat x y
 convertPathElement pat (CurveTo x1 y1 x2 y2 x3 y3) = meshPatternCurveTo pat x1 y1 x2 y2 x3 y3
 convertPathElement  _  ClosePath                   = return ()
 
-meshPatternAddPatchRGB :: Pattern -> [PathElement] -> [(Double,Double)] -> [(Double,Double,Double)] -> IO Status
-meshPatternAddPatchRGB pat elems controlPoints colors = do
-   meshPatternBeginPatch pat
-   mapM_ (convertPathElement pat) (take 4 elems)
-   sequence_ $ zipWith (\(x,y) n -> meshPatternSetControlPoint pat n x y) (take 4 controlPoints) [0..3]
-   sequence_ $ zipWith (\(r,g,b) n -> meshPatternSetCornerColorRGB pat n r g b) (take 4 colors) [0..3]
-   meshPatternEndPatch pat
-   patternStatus pat
-
-meshPatternAddPatchRGBA :: Pattern -> [PathElement] -> [(Double,Double)] -> [(Double,Double,Double,Double)] -> IO Status
-meshPatternAddPatchRGBA pat elems controlPoints colors = do
-   meshPatternBeginPatch pat
-   mapM_ (convertPathElement pat) (take 4 elems)
-   sequence_ $ zipWith (\(x,y) n -> meshPatternSetControlPoint pat n x y) (take 4 controlPoints) [0..3]
-   sequence_ $ zipWith (\(r,g,b,a) n -> meshPatternSetCornerColorRGBA pat n r g b a) (take 4 colors) [0..3]
-   meshPatternEndPatch pat
-   patternStatus pat
-
 #endif
 


### PR DESCRIPTION
Added support for mesh patterns (tensor-product patch meshes which support Postscript/PDF shading types 4—7.  See the cairographics API documentation for all the details.  For the most part, this patch simply wraps the C API.

I modified the `Pattern` type to be a `ForeignPtr` type rather than an ordinary pointer.  I added functions `createRGBPattern`, `createLinearPattern`, &al to create patterns of various sorts.  Of course there is a new function `createMeshPattern`.  There are also convenience functions (not in the C API) `meshPatternAddPatchRGB` and `meshPatternAddPatchRGBA` to add a patch to a mesh pattern in a single call.

The functions `withRGBPattern`, `withLinearPattern`, &al. were modified so that they no longer manually dispose of the pattern but rather relegate the disposal to the foreign pointer finalizer.  These functions are no longer needed or useful.

Previously, the only way to construct the `Pattern` type was inside of the `with*Pattern` functions.  Downstream users may very well have an issue using these functions inside of timer that redraws a GTK widget.  Such users should modify their code to use `create*Pattern` to create the pattern once and refer to it when it is used.  Other users having problems with resource consumption of the foreign pointers should turn to something like `ResourceT` to manage resources.

I also added the `pathExtents` function which I overlooked in my last patch.
