### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -94,4 +94,4 @@ Library
         if flag(cairo_svg)
           pkgconfig-depends: cairo-svg
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=

--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -83,7 +83,7 @@ Library
 		
         cpp-options:    -U__BLOCKS__ -Ubool
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
 
         x-Signals-File:  System/GIO/Signals.chs
         x-Signals-Modname: System.GIO.Signals

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -43,7 +43,7 @@ Library
                         containers
         cpp-options:    -U__BLOCKS__
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
         if flag(closure_signals)
           cpp-options:  -DUSE_GCLOSURE_SIGNALS_IMPL
           c-sources: System/Glib/hsgclosure.c

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -374,7 +374,7 @@ Library
         include-dirs:   .
         cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
         if os(windows)
           cpp-options:    -DWIN32 -fno-exceptions
           cc-options:     -fno-exceptions

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -80,7 +80,7 @@ Library
         include-dirs:   .
         cpp-options:    -U__BLOCKS__
         if os(darwin) || os(freebsd)
-          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
+          cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull= -D_Noreturn=
         if os(windows)
           cpp-options: -D__USE_MINGW_ANSI_STDIO=1
         -- Pango 1.26 has a mysterious bug that makes it go into an infinite


### PR DESCRIPTION
Standard library headers such as stdlib.h on FreeBSD use _Noreturn in
addition to the other attributes that have been muted here.