### PR TITLE
Fix Cairo hyperlink

### DIFF
--- a/pango/Graphics/Rendering/Pango.chs
+++ b/pango/Graphics/Rendering/Pango.chs
@@ -37,7 +37,7 @@
 -- * Native fonts on MacOS X using ATSUI for complex-text handling.
 --
 -- The integration of Pango
--- with Cairo <http://cairographics.org/> provides a complete solution with
+-- with Cairo <https://cairographics.org> provides a complete solution with
 -- high quality text handling and graphics rendering.
 --
 -- Dynamically loaded modules then handle text layout for particular


### PR DESCRIPTION
This paragraph shows up in the generated HTML as

> The integration of Pango with Cairo <http: high quality text handling and graphics rendering.

I think removing the trailing slash should fix it?

That site also supports HTTPS now, so I've updated the URL here accordingly.