### PR TITLE
Fix for #288: build failure of glib under MinGW.

### DIFF
--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -81,7 +81,7 @@ Library
         default-language:   Haskell98
         default-extensions: ForeignFunctionInterface
 
-        cpp-options:    -U__BLOCKS__ -Ubool -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__ -Ubool -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
 

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -41,7 +41,7 @@ Library
                         bytestring >= 0.9.1.10 && < 0.11,
                         text >= 1.0.0.0 && < 1.3,
                         containers
-        cpp-options:    -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
         if flag(closure_signals)

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -381,7 +381,7 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull=
         if !flag(deprecated)

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -372,7 +372,7 @@ Library
         -- needs to be imported from this module:
         x-Signals-Import: Graphics.UI.Gtk.General.Threading
         include-dirs:   .
-        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
         if os(windows)

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -78,7 +78,7 @@ Library
         x-c2hs-Header:  hspango.h
         includes:       hspango.h
         include-dirs:   .
-        cpp-options:    -U__BLOCKS__ -D__attribute__(A)=
+        cpp-options:    -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
           cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
         if os(windows)


### PR DESCRIPTION
Rather than removing all uses of __attribute__ we just take out the
ones for deprecation warnings.