### PR TITLE
Fix building on macOS

### DIFF
--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -83,7 +83,7 @@ Library
 
         cpp-options:    -U__BLOCKS__ -Ubool -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
-          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
+          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn= -D__attribute__(x)=
 
         x-Signals-File:  System/GIO/Signals.chs
         x-Signals-Modname: System.GIO.Signals

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -43,7 +43,7 @@ Library
                         containers
         cpp-options:    -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
-          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
+          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn= -D__attribute__(x)=
         if flag(closure_signals)
           cpp-options:  -DUSE_GCLOSURE_SIGNALS_IMPL
           c-sources: System/Glib/hsgclosure.c

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -383,7 +383,7 @@ Library
         include-dirs:   .
         cpp-options: -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
-          cpp-options: -D_Nullable= -D_Nonnull=
+          cpp-options: -D_Nullable= -D_Nonnull= -D__attribute__(x)=
         if !flag(deprecated)
           cpp-options:  -DDISABLE_DEPRECATED
         else

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -374,7 +374,7 @@ Library
         include-dirs:   .
         cpp-options: -DDISABLE_DEPRECATED -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
-          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
+          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn= -D__attribute__(x)=
         if os(windows)
           cpp-options:    -DWIN32 -fno-exceptions
           cc-options:     -fno-exceptions

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -80,7 +80,7 @@ Library
         include-dirs:   .
         cpp-options:    -U__BLOCKS__ -DGLIB_DISABLE_DEPRECATION_WARNINGS
         if os(darwin) || os(freebsd)
-          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn=
+          cpp-options: -D_Nullable= -D_Nonnull= -D_Noreturn= -D__attribute__(x)=
         if os(windows)
           cpp-options: -D__USE_MINGW_ANSI_STDIO=1
         -- Pango 1.26 has a mysterious bug that makes it go into an infinite


### PR DESCRIPTION
Resolves #291 (at least on Mojave, but the error looks identical to that reported)

The issue is that the macOS `<time.h>` includes attribute metadata (mapping symbols to supported OS versions) that confuses `c2hs`.

Thank you for gtk2hs!

Edit: This applies to multiple sub-packages, not just glib - fixing all of them.
Edit: also include the gtk2 .cabal-renamed that was originally missed