### PR TITLE
Cairo: add SVG surface units

### DIFF
--- a/cairo/Graphics/Rendering/Cairo.hs
+++ b/cairo/Graphics/Rendering/Cairo.hs
@@ -250,6 +250,10 @@ module Graphics.Rendering.Cairo (
 #ifdef CAIRO_HAS_SVG_SURFACE
   -- ** SVG surfaces
   , withSVGSurface
+#if CAIRO_CHECK_VERSION(1,16,0)
+  , svgSurfaceSetDocumentUnit
+  , svgSurfaceGetDocumentUnit
+#endif
 #endif
 
 #if CAIRO_CHECK_VERSION(1,10,0)
@@ -320,6 +324,12 @@ module Graphics.Rendering.Cairo (
   , Format(..)
   , Extend(..)
   , Filter(..)
+
+#ifdef CAIRO_HAS_SVG_SURFACE
+#if CAIRO_CHECK_VERSION(1,16,0)
+  , SvgUnit(..)
+#endif
+#endif
 
   -- mesh patterns
 #if CAIRO_CHECK_VERSION(1,12,0)
@@ -2333,8 +2343,14 @@ psSurfaceSetSize s x y = liftIO $ Internal.psSurfaceSetSize s x y
 --
 withSVGSurface ::
      FilePath -- ^ @filename@ - a filename for the SVG output (must be writable)
-  -> Double   -- ^ width of the surface, in points (1 point == 1\/72.0 inch)
-  -> Double   -- ^ height of the surface, in points (1 point == 1\/72.0 inch)
+  -> Double   -- ^ Width of the surface. The default unit is points (1 point == 1\/72.0 inch)
+#if CAIRO_CHECK_VERSION(1,16,0)
+              -- and can be changed with 'svgSurfaceSetDocumentUnit'.
+#endif
+  -> Double   -- ^ Height of the surface. The default unit is points (1 point == 1\/72.0 inch)
+#if CAIRO_CHECK_VERSION(1,16,0)
+              -- and can be changed with 'svgSurfaceSetDocumentUnit'.
+#endif
   -> (Surface -> IO a) -- ^ an action that may use the surface. The surface is
                        -- only valid within in this action.
   -> IO a
@@ -2345,6 +2361,16 @@ withSVGSurface filename width height f =
                           unless (status == StatusSuccess) $
                             Internal.statusToString status >>= fail)
           (\surface -> f surface)
+
+#if CAIRO_CHECK_VERSION(1,16,0)
+-- | Use the specified unit for the width and height of the generated SVG file.
+svgSurfaceSetDocumentUnit :: MonadIO m => Surface -> SvgUnit -> m ()
+svgSurfaceSetDocumentUnit s unit = liftIO $ Internal.svgSurfaceSetDocumentUnit s unit
+
+-- | Get the specified unit for the width and height of the generated SVG file.
+svgSurfaceGetDocumentUnit :: MonadIO m => Surface -> m SvgUnit
+svgSurfaceGetDocumentUnit s = liftIO $ Internal.svgSurfaceGetDocumentUnit s
+#endif
 #endif
 
 #if CAIRO_CHECK_VERSION(1,10,0)

--- a/cairo/Graphics/Rendering/Cairo/Internal/Surfaces/SVG.chs
+++ b/cairo/Graphics/Rendering/Cairo/Internal/Surfaces/SVG.chs
@@ -25,4 +25,9 @@ import Foreign.C
 
 {#fun svg_surface_create  as svgSurfaceCreate { withCAString* `FilePath', `Double', `Double' } -> `Surface' mkSurface*#}
 
+#if CAIRO_CHECK_VERSION(1,16,0)
+{#fun svg_surface_set_document_unit as svgSurfaceSetDocumentUnit { withSurface* `Surface', cFromEnum `SvgUnit' } -> `()'#}
+{#fun svg_surface_get_document_unit as svgSurfaceGetDocumentUnit { withSurface* `Surface' } -> `SvgUnit' cToEnum#}
+#endif
+
 #endif

--- a/cairo/Graphics/Rendering/Cairo/Types.chs
+++ b/cairo/Graphics/Rendering/Cairo/Types.chs
@@ -51,6 +51,11 @@ module Graphics.Rendering.Cairo.Types (
   , Filter(..)
   , SurfaceType(..)
   , PatternType(..)
+#ifdef CAIRO_HAS_SVG_SURFACE
+#if CAIRO_CHECK_VERSION(1,16,0)
+  , SvgUnit(..)
+#endif
+#endif
 
   , cIntConv
   , cFloatConv
@@ -426,6 +431,13 @@ foreign import ccall unsafe "&cairo_region_destroy"
 
 -- | Specify how filtering is done.
 {#enum filter_t as Filter {underscoreToCase} deriving(Eq,Show)#}
+
+#ifdef CAIRO_HAS_SVG_SURFACE
+#if CAIRO_CHECK_VERSION(1,16,0)
+-- | Specify the unit used in SVG surfaces.
+{#enum svg_unit_t as SvgUnit {underscoreToCase} deriving(Eq, Show) #}
+#endif
+#endif
 
 -- Marshalling functions
 

--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 Name:           cairo
-Version:        0.13.8.2
+Version:        0.13.9.0
 License:        BSD-3-Clause
 License-file:   COPYRIGHT
 Copyright:      (c) 2001-2010 The Gtk2Hs Team, (c) Paolo Martini 2005, (c) Abraham Egnor 2003, 2004, (c) Aetion Technologies LLC 2004


### PR DESCRIPTION
# Description

Cairo’s SVG backend uses points as default unit for historical reasons [(source)][historical], which often leads to surprises, since rendering a picture as SVG using the »same« width/height is considerably larger than PNG.

This patch adds bindings to Cairo’s functions to alter this unit ([`cairo_svg_surface_{get,set}_document_unit`][cairodoc]):

# Functionality added

![](https://user-images.githubusercontent.com/3020161/161522136-2df23463-a1a6-4147-8943-be78abddb535.png)

[historical]: https://www.cairographics.org/manual/cairo-SVG-Surfaces.html#cairo-svg-surface-set-document-unit
[cairodoc]: https://www.cairographics.org/manual/cairo-SVG-Surfaces.html#cairo-svg-surface-get-document-unit

# Tests

Everything works as expected:

```haskell
withSVGSurface "test.svg" 100 100 $ \surface -> renderWith surface $ do
    currentUnit <- svgSurfaceGetDocumentUnit surface
    liftIO (print currentUnit) -- ==> SvgUnitPt

    svgSurfaceSetDocumentUnit surface SvgUnitPx
    
    newUnit <- svgSurfaceGetDocumentUnit surface
    liftIO (print newUnit) -- ==> SvgUnitPx

    rectangle 10 10 80 80 
    stroke

-- SVG output with width="100px" height="100px", not pt (default without changing the units).
```