### PR TITLE
fix(pango): add `PANGO_WRAP_NONE` as `WrapNowhere` to avoid name conflict

### DIFF
--- a/pango/Graphics/Rendering/Pango/Layout.chs
+++ b/pango/Graphics/Rendering/Pango/Layout.chs
@@ -356,11 +356,20 @@ layoutGetWidth (PangoLayout _ pl) = do
 --   a word if it is the only one on this line and it exceeds the
 --   specified width.
 --
+#if PANGO_VERSION_CHECK(1,56,0)
+{#enum PangoWrapMode as LayoutWrapMode
+  {underscoreToCase,
+  PANGO_WRAP_WORD as WrapWholeWords,
+  PANGO_WRAP_CHAR as WrapAnywhere,
+  PANGO_WRAP_WORD_CHAR as WrapPartialWords,
+  PANGO_WRAP_NONE as WrapNowhere}#}
+#else
 {#enum PangoWrapMode as LayoutWrapMode
   {underscoreToCase,
   PANGO_WRAP_WORD as WrapWholeWords,
   PANGO_WRAP_CHAR as WrapAnywhere,
   PANGO_WRAP_WORD_CHAR as WrapPartialWords}#}
+#endif
 
 -- | Set how this paragraph is wrapped.
 --


### PR DESCRIPTION
This PR explicitly maps the new `PANGO_WRAP_NONE` option to `WrapNowhere` to match `WrapAnywhere` and avoid a conflict with the `WrapNone` constructor of `WrapMode` defined in `Graphics.UI.Gtk.General.Enums`.