### PR TITLE
gtk2hs-buildtools: Remove noncanonical definitions

### DIFF
--- a/tools/c2hs/base/state/StateBase.hs
+++ b/tools/c2hs/base/state/StateBase.hs
@@ -103,13 +103,14 @@ instance Functor (PreCST e s) where
   fmap = liftM
 
 instance Applicative (PreCST e s) where
-  pure  = return
+  pure  = yield
   (<*>) = ap
+  (*>)  = (+>)
 
 instance Monad (PreCST e s) where
-  return = yield
+  return = pure
   (>>=)  = (+>=)
-  (>>)   = (+>)
+  (>>)   = (*>)
 
 instance MonadFail (PreCST e s) where
   fail = error

--- a/tools/c2hs/base/state/StateTrans.hs
+++ b/tools/c2hs/base/state/StateTrans.hs
@@ -120,13 +120,14 @@ instance Functor (STB bs gs) where
   fmap = liftM
 
 instance Applicative (STB bs gs) where
-  pure  = return
+  pure  = yield
   (<*>) = ap
+  (*>)  = (+>)
 
 instance Monad (STB bs gs) where
-  return = yield
+  return = pure
   (>>=)  = (+>=)
-  (>>)   = (+>)
+  (>>)   = (*>)
 
 -- the monad's unit
 --

--- a/tools/c2hs/c/CParserMonad.hs
+++ b/tools/c2hs/c/CParserMonad.hs
@@ -92,11 +92,11 @@ instance Functor P where
   fmap = liftM
 
 instance Applicative P where
-  pure = return
+  pure = returnP
   (<*>) = ap
 
 instance Monad P where
-  return = returnP
+  return = pure
   (>>=) = thenP
 
 #if !MIN_VERSION_base(4,13,0)


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return