### PR TITLE
fix: build to success to strict env

### DIFF
--- a/cairo/Graphics/Rendering/Cairo.hs
+++ b/cairo/Graphics/Rendering/Cairo.hs
@@ -1066,7 +1066,7 @@ pathExtents = liftRender0 Internal.pathExtents
 
 
 
--- | 
+-- |
 --
 createRGBPattern ::
       MonadIO m =>
@@ -1077,7 +1077,7 @@ createRGBPattern ::
 createRGBPattern r g b = liftIO$ Internal.patternCreateRGB r g b
 
 
--- | 
+-- |
 --
 createRGBAPattern ::
       MonadIO m =>
@@ -1089,7 +1089,7 @@ createRGBAPattern ::
 createRGBAPattern r g b a = liftIO$ Internal.patternCreateRGBA r g b a
 
 
--- | 
+-- |
 --
 createLinearPattern ::
       MonadIO m =>
@@ -1101,7 +1101,7 @@ createLinearPattern ::
 createLinearPattern x1 y1 x2 y2 = liftIO$ Internal.patternCreateLinear x1 y1 x2 y2
 
 
--- | 
+-- |
 --
 createRadialPattern ::
       MonadIO m =>
@@ -1380,7 +1380,7 @@ createMeshPattern = liftIO$ Internal.patternCreateMesh
 -- It translates the provided path into calls to meshPatternMoveTo, meshPatternLineTo, and
 -- meshPatternCurveTo, as appropriate.  The control points are set using meshPatternSetControlPoint
 -- and the corner colors are set using meshPatternSetCornerColorRGB.
--- The above operations are wrapped in calls to 
+-- The above operations are wrapped in calls to
 -- At most the first 4 elements of the provided list will be used.
 meshPatternAddPatchRGB ::
       MonadIO m =>
@@ -1718,7 +1718,7 @@ getFontMatrix = liftRender0 Internal.getFontMatrix
 --
 setFontOptions :: FontOptions -> Render ()
 setFontOptions = liftRender1 Internal.setFontOptions
-        
+
 -- | A drawing operator that generates the shape from a string of Unicode
 -- characters, rendered according to the current font face, font size (font
 -- matrix), and font options.

--- a/cairo/cairo.cabal
+++ b/cairo/cairo.cabal
@@ -54,7 +54,7 @@ Flag cairo_svg
 custom-setup
   setup-depends: base >= 4.6 && <5,
                  Cabal >= 3.0 && < 3.15,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4.8 && < 5,

--- a/gio/gio.cabal
+++ b/gio/gio.cabal
@@ -41,7 +41,7 @@ Source-Repository head
 custom-setup
   setup-depends: base >= 4.6 && < 5,
                  Cabal >= 3.0 && < 3.15,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5,

--- a/glib/System/Glib/hsgclosure.c
+++ b/glib/System/Glib/hsgclosure.c
@@ -84,16 +84,16 @@ gtk2hs_closure_marshal(GClosure *closure,
     SchedulerStatus cap;
 #endif
     guint i;
-    
+
     WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): about to run callback, n_param_values=%d", hc->callback, n_param_values));
 #ifdef GHC_RTS_USES_CAPABILITY
     cap = rts_lock();
 #else
     rts_lock();
 #endif
-    
+
     call = (StgClosure *)deRefStablePtr(hc->callback);
-   
+
     /* construct the function call */
     for (i = 0; i < n_param_values; i++) {
         WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): param_values[%d]=%s :: %s",
@@ -103,9 +103,9 @@ gtk2hs_closure_marshal(GClosure *closure,
                            g_type_name(G_VALUE_TYPE(&param_values[i]))));
         call = rts_apply(CAP call, gtk2hs_value_as_haskellobj(CAP &param_values[i]));
     }
-    
+
     WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): about to rts_evalIO", hc->callback));
-    
+
     /* perform the call */
     #if __GLASGOW_HASKELL__>=704
     rts_evalIO(&cap, rts_apply(CAP (HaskellObj)runIO_closure, call),&ret);
@@ -114,13 +114,13 @@ gtk2hs_closure_marshal(GClosure *closure,
     #endif
 
     WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): about to rts_checkSchedStatus", hc->callback));
-    
+
     /* barf if anything went wrong */
     /* TODO: pass a sensible value for call site so we get better error messages */
     /* or perhaps we can propagate any error? */
     rts_checkSchedStatus("gtk2hs_closure_marshal", cap);
     WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): ret=%p", hc->callback, ret));
-    
+
     if (return_value) {
         WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): return_value :: %s, ret=%p, UNTAG_CLOSURE(ret)=%p",
 	                   hc->callback,
@@ -130,7 +130,7 @@ gtk2hs_closure_marshal(GClosure *closure,
 			   UNTAG_CLOSURE(ret)));
         gtk2hs_value_from_haskellobj(return_value, ret);
     }
-    
+
 #ifdef GHC_RTS_USES_CAPABILITY
     rts_unlock(cap);
 #else
@@ -143,7 +143,7 @@ GClosure *
 gtk2hs_closure_new(HsStablePtr callback)
 {
     GClosure *closure;
-    
+
     WHEN_DEBUG(g_debug("gtk2hs_closure_new: enter, callback=%p", callback));
     closure = g_closure_new_simple(sizeof(Gtk2HsClosure), NULL);
     /* TODO: check if we should be using invalidate or finalise notifier */
@@ -151,9 +151,9 @@ gtk2hs_closure_new(HsStablePtr callback)
     g_closure_set_marshal(closure, gtk2hs_closure_marshal);
 
     ((Gtk2HsClosure *)closure)->callback = callback;
-    
+
     WHEN_DEBUG(g_debug("gtk2hs_closure_new: leave"));
-    
+
     return closure;
 }
 

--- a/glib/glib.cabal
+++ b/glib/glib.cabal
@@ -33,7 +33,7 @@ Flag closure_signals
 custom-setup
   setup-depends: base >= 4.6 && < 5,
                  Cabal >= 3.0 && < 3.15,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5,

--- a/gtk/Graphics/UI/Gtk/Embedding/Types.chs
+++ b/gtk/Graphics/UI/Gtk/Embedding/Types.chs
@@ -30,11 +30,11 @@ module Graphics.UI.Gtk.Embedding.Types (
 
 #if (defined(HAVE_PLUG_AND_SOCKET) && (!defined(WIN32) || GTK_CHECK_VERSION(2,8,0))) || defined(GDK_WINDOWING_X11)
   Socket(Socket), SocketClass,
-  toSocket, 
+  toSocket,
   mkSocket, unSocket,
   castToSocket, gTypeSocket,
   Plug(Plug), PlugClass,
-  toPlug, 
+  toPlug,
   mkPlug, unPlug,
   castToPlug, gTypePlug,
 #endif

--- a/gtk/Graphics/UI/Gtk/Gdk/Pixbuf.chs
+++ b/gtk/Graphics/UI/Gtk/Gdk/Pixbuf.chs
@@ -377,7 +377,7 @@ pixbufNewFromSurface surface srcX srcY width height =
 -- Transfers image data from a GdkWindow and converts it to an RGB(A) representation inside a GdkPixbuf. In other words, copies image data from a server-side drawable to a client-side RGB(A) buffer. This allows you to efficiently read individual pixels on the client side.
 --
 -- This function will create an RGB pixbuf with 8 bits per channel with the size specified by the width and height arguments scaled by the scale factor of window. The pixbuf will contain an alpha channel if the window contains one.
-pixbufNewFromWindow :: DrawWindowClass self 
+pixbufNewFromWindow :: DrawWindowClass self
   => self -- ^ @window@ - The source window.
   -> Int -- ^ @srcX@ - Source X coordinate within window.
   -> Int -- ^ @srcY@ - Source Y coordinate within window.

--- a/gtk/Graphics/UI/Gtk/General/Drag.chs
+++ b/gtk/Graphics/UI/Gtk/General/Drag.chs
@@ -264,7 +264,7 @@ dragDestFindTarget widget context Nothing = do
     (toDragContext context)
     (TargetList nullForeignPtr)
   if ttPtr==nullPtr then return Nothing else return (Just (Atom ttPtr))
-        
+
 -- %hash c:41c7 d:af3f
 -- | Returns the list of targets this widget can accept for drag-and-drop.
 --

--- a/gtk/Graphics/UI/Gtk/General/Enums.chs
+++ b/gtk/Graphics/UI/Gtk/General/Enums.chs
@@ -147,7 +147,7 @@ instance Flags AccelFlags
 instance Flags AttachOptions
 
 #if GTK_CHECK_VERSION(3,10,0)
--- | Whenever a container has some form of natural row it may align children in 
+-- | Whenever a container has some form of natural row it may align children in
 -- that row along a common typographical baseline. If the amount of vertical space
 -- in the row is taller than the total requested height of the baseline-aligned
 -- children then it can use a BaselinePosition to select where to put the

--- a/gtk/Graphics/UI/Gtk/General/hsgthread.c
+++ b/gtk/Graphics/UI/Gtk/General/hsgthread.c
@@ -73,12 +73,12 @@ void gtk2hs_initialise (void) {
 	/* Some Windows GTK binaries (current Fedora MinGW ones) do */
 	/* not open files in binary mode.  This is a work around.    */
     HANDLE handle = LoadLibrary("MSVCRT.dll");
-    if(!handle) { 
+    if(!handle) {
         fprintf(stderr, "Warning: failed to load MSVCRT.dll, ");
         fprintf(stderr, "binary mode was not set!\n");
         return;
     }
-    
+
     int *_fmode_ptr = GetProcAddress(handle, "_fmode");
     if(!_fmode_ptr) {
         fprintf(stderr, "Warning: failed to load address of _fmode from MSVCRT.dll, ");
@@ -107,7 +107,7 @@ void gtk2hs_threads_initialise (void) {
 
 #if defined( WIN32 ) && GLIB_CHECK_VERSION(2,32,0)
     g_rec_mutex_init(&recursive_mutex);
-    
+
     gdk_threads_set_lock_functions(imp_rec_lock, imp_rec_unlock);
 #endif
     gdk_threads_init();
@@ -188,7 +188,7 @@ gboolean gtk2hs_run_finalizers(gpointer data) {
   g_assert(gtk2hs_finalizers!=NULL);
 
   gdk_threads_enter();
-	
+
   int mutex_locked = 0;
   if (threads_initialised) {
 #ifdef DEBUG

--- a/gtk/Graphics/UI/Gtk/General/hsgthread.c
+++ b/gtk/Graphics/UI/Gtk/General/hsgthread.c
@@ -31,8 +31,9 @@
 #define DEFINE_LPCREATETYPEINFO
 #define DEFINED_LPDISPATCH
 
-#include <glib.h>
 #include <gdk/gdk.h>
+#include <glib.h>
+#include <gtk/gtk.h>
 #include "hsgthread.h"
 
 #if defined( WIN32 )
@@ -110,10 +111,11 @@ void gtk2hs_threads_initialise (void) {
 
     gdk_threads_set_lock_functions(imp_rec_lock, imp_rec_unlock);
 #endif
-    gdk_threads_init();
-
     /* from here onwards, the Gdk lock is held */
+#if !GTK_CHECK_VERSION(3,6,0)
+    gdk_threads_init();
     gdk_threads_enter();
+#endif
 
   }
 }
@@ -187,7 +189,9 @@ gboolean gtk2hs_run_finalizers(gpointer data) {
   gint index;
   g_assert(gtk2hs_finalizers!=NULL);
 
+#if !GTK_CHECK_VERSION(3,6,0)
   gdk_threads_enter();
+#endif
 
   int mutex_locked = 0;
   if (threads_initialised) {
@@ -224,8 +228,9 @@ gboolean gtk2hs_run_finalizers(gpointer data) {
 #endif
   }
 
+#if !GTK_CHECK_VERSION(3,6,0)
   gdk_threads_leave();
+#endif
 
   return FALSE;
 }
-

--- a/gtk/Graphics/UI/Gtk/Layout/Stack.chs
+++ b/gtk/Graphics/UI/Gtk/Layout/Stack.chs
@@ -37,7 +37,7 @@ module Graphics.UI.Gtk.Layout.Stack (
 -- Transitions between pages can be animated as slides or fades. This
 -- can be controlled with 'stackSetTransitionType'. These
 -- animations respect the 'gtk-enable-animations' setting.
---       
+--
 -- The GtkStack widget was added in GTK+ 3.10.
 --
 -- * Class Hierarchy

--- a/gtk/Graphics/UI/Gtk/ModelView/CellRenderer.chs
+++ b/gtk/Graphics/UI/Gtk/ModelView/CellRenderer.chs
@@ -27,7 +27,7 @@
 --
 module Graphics.UI.Gtk.ModelView.CellRenderer (
 -- * Detail
---      
+--
 -- | The 'CellRenderer' is a base class of a set of objects used for rendering
 -- a cell to a 'Drawable'. These objects are used primarily by the 'TreeView'
 -- widget, though they aren't tied to them in any specific way. It is worth

--- a/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.c
+++ b/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.c
@@ -83,7 +83,7 @@ static gboolean     gtk2hs_store_drag_data_received     (GtkTreeDragDest        
 static gboolean     gtk2hs_store_row_drop_possible      (GtkTreeDragDest        *drag_dest,
                                                          GtkTreePath            *dest_path,
                                                          GtkSelectionData       *selection_data);
-                                                                                          
+
 static GObjectClass *parent_class = NULL;
 
 
@@ -151,17 +151,17 @@ gtk2hs_store_get_type (void)
 
     g_type_add_interface_static (gtk2hs_store_type, GTK_TYPE_TREE_MODEL,
     &tree_model_info);
-    
+
     /* The TreeSortable interface is currently not implemented. Uncomment to
     add it. */
 /*    g_type_add_interface_static (gtk2hs_store_type,
                                  GTK_TYPE_TREE_SORTABLE,
                                  &tree_sortable_info);
-*/                                 
+*/
     g_type_add_interface_static (gtk2hs_store_type,
                                  GTK_TYPE_TREE_DRAG_SOURCE,
                                  &tree_drag_source_info);
-                                 
+
     g_type_add_interface_static (gtk2hs_store_type,
                                  GTK_TYPE_TREE_DRAG_DEST,
                                  &tree_drag_dest_info);
@@ -364,7 +364,7 @@ gtk2hs_store_get_column_type (GtkTreeModel *tree_model,
   WHEN_DEBUG(g_debug("calling gtk2hs_store_get_column_type\t(%p, %d)\n", tree_model, index));
   Gtk2HsStore *store = (Gtk2HsStore *) tree_model;
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), G_TYPE_INVALID);
-  
+
   GType result = gtk2hs_store_get_column_type_impl(store->impl, index);
   WHEN_DEBUG(g_debug("return  gtk2hs_store_get_column_type\t=%s\n", g_type_name(result)));
   return result;
@@ -412,7 +412,7 @@ gtk2hs_store_get_path (GtkTreeModel *tree_model,
   Gtk2HsStore *store = (Gtk2HsStore *) tree_model;
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), NULL);
   g_return_val_if_fail (iter->stamp == store->stamp, NULL);
-  
+
   GtkTreePath * result = gtk2hs_store_get_path_impl(store->impl, iter);
   WHEN_DEBUG(
     gchar *result_str = gtk_tree_path_to_string(result);
@@ -511,7 +511,7 @@ gtk2hs_store_iter_has_child (GtkTreeModel *tree_model,
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), FALSE);
   /* don't check if iter->stamp == store->stamp; see the thread culminating in
    * http://sourceforge.net/p/gtk2hs/mailman/message/31887332/ for details */
-  
+
   gboolean result = gtk2hs_store_iter_has_child_impl(store->impl, iter);
   WHEN_DEBUG(g_debug("return  gtk2hs_store_iter_has_child\t=%s\n", result ? "TRUE" : "FALSE"));
   return result;
@@ -587,7 +587,7 @@ gtk2hs_store_iter_parent (GtkTreeModel *tree_model,
   g_return_val_if_fail (GTK2HS_IS_STORE (tree_model), FALSE);
   g_return_val_if_fail (child != NULL, FALSE);
   g_return_val_if_fail (child->stamp == store->stamp, FALSE);
- 
+
   gboolean result = gtk2hs_store_iter_parent_impl(store->impl, iter, child);
   if (result) iter->stamp = store->stamp;
   WHEN_DEBUG(g_debug("return  gtk2hs_store_iter_parent\t\t=%s\n", result ? "TRUE" : "FALSE"));
@@ -626,7 +626,7 @@ gtk2hs_store_get_sort_column_id     (GtkTreeSortable        *sortable,
   WHEN_DEBUG(g_debug("calling gtk2hs_store_get_sort_column_id\t\t(%p)\n", sortable));
   return 0;
 }
-         
+
 static void
 gtk2hs_store_set_sort_column_id (GtkTreeSortable        *sortable,
                                  gint                   sort_column_id,
@@ -645,7 +645,7 @@ gtk2hs_store_set_sort_func (GtkTreeSortable        *sortable,
                             GtkDestroyNotify       destroy)
 {
   WHEN_DEBUG(g_debug("calling gtk2hs_store_set_sort_func\t\t(%p)\n", sortable));
-  return;  
+  return;
 }
 
 static void
@@ -675,7 +675,7 @@ gtk2hs_store_row_draggable (GtkTreeDragSource *drag_source,
   )
   Gtk2HsStore *store = (Gtk2HsStore *) drag_source;
   g_return_val_if_fail (GTK2HS_IS_STORE (drag_source), FALSE);
-                    
+
   gboolean result = gtk2hs_store_row_draggable_impl(drag_source, store->impl, path);
   WHEN_DEBUG(g_debug("return  gtk2hs_store_row_draggable\t\t=%s\n", result ? "TRUE" : "FALSE"));
   return result;
@@ -693,7 +693,7 @@ gtk2hs_store_drag_data_get (GtkTreeDragSource *drag_source,
   Gtk2HsStore *store = (Gtk2HsStore *) drag_source;
   g_return_val_if_fail (GTK2HS_IS_STORE (drag_source), FALSE);
   g_return_val_if_fail (selection_data!=NULL, FALSE);
-  
+
   gboolean result = gtk2hs_store_drag_data_get_impl(drag_source, store->impl, path, selection_data);
   WHEN_DEBUG(g_debug("return  gtk2hs_store_drag_data_get\t\t=%s\n", result ? "TRUE" : "FALSE"));
   return result;

--- a/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.h
+++ b/gtk/Graphics/UI/Gtk/ModelView/Gtk2HsStore.h
@@ -20,7 +20,7 @@ typedef struct _Gtk2HsStoreClass  Gtk2HsStoreClass;
 struct _Gtk2HsStore
 {
   GObject parent;
-  
+
   /*< private >*/
   HsStablePtr     impl;        /* a StablePtr CustomStore */
   HsStablePtr     priv;        /* a StablePtr to private data */

--- a/gtk/Graphics/UI/Gtk/Selectors/FileChooser.chs
+++ b/gtk/Graphics/UI/Gtk/Selectors/FileChooser.chs
@@ -113,7 +113,7 @@ module Graphics.UI.Gtk.Selectors.FileChooser (
 -- > }
 -- >
 -- > class "GtkFileChooserDefault" binding "my-own-gtkfilechooser-bindings"
--- >    
+-- >
 --
 
 -- * Class Hierarchy

--- a/gtk/Graphics/UI/Gtk/Selectors/FileChooserButton.chs
+++ b/gtk/Graphics/UI/Gtk/Selectors/FileChooserButton.chs
@@ -77,7 +77,7 @@ module Graphics.UI.Gtk.Selectors.FileChooserButton (
   fileChooserButtonWidthChars,
 
 -- * Signals
-  fileChooserButtonFileSet 
+  fileChooserButtonFileSet
 #endif
   ) where
 

--- a/gtk/Graphics/UI/Gtk/Windows/MessageDialog.chs
+++ b/gtk/Graphics/UI/Gtk/Windows/MessageDialog.chs
@@ -162,8 +162,8 @@ messageDialogNew mWindow flags mType bType msg =
   makeNewObject mkMessageDialog $
   liftM (castPtr :: Ptr Widget -> Ptr MessageDialog) $
   call_message_dialog_new mWindow flags mType bType msgPtr
-                                
-                                
+
+
 call_message_dialog_new :: Maybe Window -> [DialogFlags] ->
                            MessageType -> ButtonsType -> Ptr CChar ->
                            IO (Ptr Widget)
@@ -238,7 +238,7 @@ messageDialogSetSecondaryMarkup self str =
 foreign import ccall unsafe "gtk_message_dialog_format_secondary_markup"
   message_dialog_format_secondary_markup :: Ptr MessageDialog ->
                                            Ptr CChar -> IO ()
-                                        
+
 messageDialogSetSecondaryText :: (MessageDialogClass self, GlibString string) => self
  -> string -- ^ @str@ - text to be shown as second line
  -> IO ()

--- a/gtk/demo/demos.txt
+++ b/gtk/demo/demos.txt
@@ -70,8 +70,8 @@ pango: use pango (http://www.pango.org/) layout to make a long paragraph adjust 
 Needs: --enable-cairo and/or cairo lib installed at Gtk2HS build time(to render the fonts)
 
 profileviewer: This is a slightly larger demo that combines use of glade, the file chooser
-  dialog, program state (IORefs) and use of the mogul tree view wrapper interface. 
-  The program is a simple viewer for the log files that ghc produces when you do time profiling. 
+  dialog, program state (IORefs) and use of the mogul tree view wrapper interface.
+  The program is a simple viewer for the log files that ghc produces when you do time profiling.
 
 soe: SOE (School of Expression) is an alternative implementation of the graphics library used in
   a book by Paul Hudak, http://www.haskell.org/soe/.

--- a/gtk/demo/stack/Stack.hs
+++ b/gtk/demo/stack/Stack.hs
@@ -18,7 +18,7 @@ main = do
   -- Creates a new button with the label "Hello World".
 
   vBox <- vBoxNew False 0
-  
+
   checkbutton <- checkButtonNewWithLabel "Click me!"
   -- stackSwitcher <- labelNew (Just "foo")
   -- stack <- labelNew (Just "bar")

--- a/gtk/gtk.cabal-renamed
+++ b/gtk/gtk.cabal-renamed
@@ -136,7 +136,7 @@ Flag fmode-binary
 custom-setup
   setup-depends: base >= 4.6 && < 5,
                  Cabal >= 3.0 && < 3.15,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5,

--- a/gtk/gtk3.cabal
+++ b/gtk/gtk3.cabal
@@ -131,7 +131,7 @@ Flag fmode-binary
 custom-setup
   setup-depends: base >= 4.6 && < 5,
                  Cabal >= 3.0 && < 3.15,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5,

--- a/gtk/hsgtk.h
+++ b/gtk/hsgtk.h
@@ -10,12 +10,12 @@
 #undef Bool
 #undef True
 #undef False
-#undef Button1 
+#undef Button1
 #undef Button2
 #undef Button3
 #undef Button4
 #undef Button5
-#undef Button1Mask 
+#undef Button1Mask
 #undef Button2Mask
 #undef Button3Mask
 #undef Button4Mask

--- a/pango/pango.cabal
+++ b/pango/pango.cabal
@@ -42,7 +42,7 @@ custom-setup
   setup-depends: base >= 4.8 && <5,
                  Cabal >= 3.0 && < 3.15,
                  filepath >= 1.3 && < 1.6,
-                 gtk2hs-buildtools >= 0.13.2.0 && < 0.14
+                 gtk2hs-buildtools >= 0.13.12.0 && < 0.14
 
 Library
         build-depends:  base >= 4.8 && < 5,
@@ -98,4 +98,3 @@ Library
         else
           pkgconfig-depends: pango >= 1.0
         pkgconfig-depends:  cairo >= 1.2.0, pangocairo >= 1.10
-

--- a/tools/apiGen/ApiGen.cabal
+++ b/tools/apiGen/ApiGen.cabal
@@ -6,5 +6,5 @@ license:        GPL
 executable:     ApiGen
 main-is:        ApiGen.hs
 hs-source-dirs: src
-other-modules:  Api, Docs, AddDocs, HaddockDocs, CodeGen, Marshal, 
+other-modules:  Api, Docs, AddDocs, HaddockDocs, CodeGen, Marshal,
                 MarshalFixup, ModuleScan, ExcludeApi, Utils, Module, Names

--- a/tools/apiGen/src/MarshalFixup.hs
+++ b/tools/apiGen/src/MarshalFixup.hs
@@ -292,7 +292,7 @@ nukeParamDocs = Map.fromList
   ,("gtk_progress_bar_get_orientation", ["returns"])
   ,("gtk_progress_bar_set_orientation", ["orientation"])
   ,("gtk_statusbar_set_has_resize_grip", ["setting"])
-  ,("gtk_statusbar_get_has_resize_grip", ["returns"])   
+  ,("gtk_statusbar_get_has_resize_grip", ["returns"])
   ,("gtk_editable_get_editable", ["returns"])
   ,("gtk_entry_set_text", ["text"])
   ,("gtk_entry_get_text", ["returns"])

--- a/tools/c2hs/base/general/Binary.hs
+++ b/tools/c2hs/base/general/Binary.hs
@@ -66,9 +66,9 @@ import Data.HashTable.Class as HashTable
               (HashTable)
 import Data.HashTable.IO as HashTable
               (BasicHashTable, toList, new, insert, lookup)
-# else
+#else
 import Data.HashTable as HashTable
-# endif
+#endif
 #endif
 import Data.Array.IO
 import Data.Array
@@ -92,7 +92,7 @@ import GHC.IOBase (IO(IO))
 import GHC.Word                 ( Word8(..) )
 # if __GLASGOW_HASKELL__<602
 import GHC.Handle               ( hSetBinaryMode )
-# endif
+#endif
 -- for debug
 import System.CPUTime           (getCPUTime)
 import Numeric                  (showFFloat)
@@ -707,9 +707,9 @@ data UserData =
 #if __GLASGOW_HASKELL__>=602
 # if __GLASGOW_HASKELL__>=707
               ud_map  :: BasicHashTable String Int -- The index of each string
-# else
+#else
               ud_map  :: HashTable String Int -- The index of each string
-# endif
+#endif
 #else
               ud_map  :: IORef (Map String Int)
 #endif
@@ -728,9 +728,9 @@ newWriteState = do
 #if __GLASGOW_HASKELL__>=602
 # if __GLASGOW_HASKELL__>=707
   out_r <- HashTable.new
-# else
+#else
   out_r <- HashTable.new (==) HashTable.hashString
-# endif
+#endif
 #else
   out_r <- newIORef Map.empty
 #endif
@@ -843,4 +843,3 @@ printElapsedTime :: String -> IO ()
 printElapsedTime msg = do
   time <- getCPUTime
   hPutStr stderr $ "elapsed time: " ++ Numeric.showFFloat (Just 2) ((fromIntegral time) / 10^12) " (" ++ msg ++ ")\n"
-

--- a/tools/c2hs/base/general/Binary.hs
+++ b/tools/c2hs/base/general/Binary.hs
@@ -653,7 +653,7 @@ getBinFileWithDict file_path = do
 
         -- Initialise the user-data field of bh
   let bh' = setUserData bh (initReadState dict)
-        
+
         -- At last, get the thing
   get bh'
 

--- a/tools/c2hs/base/state/tests/Main.hs
+++ b/tools/c2hs/base/state/tests/Main.hs
@@ -99,4 +99,4 @@ testExceptions  = putStrCIO "Testing exception handling...\n\n"             +>
                                   putStrCIO ("ATTENTION: This message must \
                                              \never show!!!\n")
 
-                                
+

--- a/tools/c2hs/base/syms/Attributes.hs
+++ b/tools/c2hs/base/syms/Attributes.hs
@@ -217,7 +217,7 @@ data Attr a =>
                  | FrozenTable (Array Name a)     -- attribute values
                                String             -- desc of the table
 
-                
+
 
 -- create an attribute table, where all attributes are `undef' (EXPORTED)
 --

--- a/tools/c2hs/base/syms/tests/Main.hs
+++ b/tools/c2hs/base/syms/tests/Main.hs
@@ -101,7 +101,7 @@ testAttrTables ns  =
   in
   if ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8
   then
-    putStrCIO "...they are ok.\n"               
+    putStrCIO "...they are ok.\n"
   else
     putStrCIO "...ERROR DETECTED: test(s) "                +>
     putIfNotOk "ok1" ok1                                   +>

--- a/tools/c2hs/base/syntax/Lexers.hs
+++ b/tools/c2hs/base/syntax/Lexers.hs
@@ -51,7 +51,7 @@
 --
 --  Given such a Haskelized regular expression `hre', we can use
 --
---    (1) hre `lexaction` \lexeme -> Nothing 
+--    (1) hre `lexaction` \lexeme -> Nothing
 --    (2) hre `lexaction` \lexeme -> Just token
 --    (3) hre `lexmeta`   \lexeme pos s -> (res, pos', s', Nothing)
 --    (4) hre `lexmeta`   \lexeme pos s -> (res, pos', s', Just l)
@@ -99,7 +99,7 @@
 --  * Unicode posses a problem as the character domain becomes too big for
 --    using arrays to represent transition tables and even sparse structures
 --    will posse a significant overhead when character ranges are naively
---    represented.  So, it might be time for finite maps again.  
+--    represented.  So, it might be time for finite maps again.
 --
 --    Regarding the character ranges, there seem to be at least two
 --    possibilities.  Doaitse explicitly uses ranges and avoids expanding
@@ -116,7 +116,7 @@
 --    around.
 --
 --  * Ken Shan <ken@digitas.harvard.edu> writes ``Section 4.3 of your paper
---    computes the definition 
+--    computes the definition
 --
 --      re1 `star` re2 = \l' -> let self = re1 self >||< re2 l' in self
 --
@@ -132,7 +132,7 @@
 module Lexers (Regexp, Lexer, Action, epsilon, char, (+>), lexaction,
 	       lexactionErr, lexmeta, (>|<), (>||<), ctrlChars, ctrlLexer,
 	       star, plus, quest, alt, string, LexerState, execLexer)
-where 
+where
 
 import Data.Maybe  (fromMaybe, isNothing)
 import Data.Array  (Ix(..), Array, array, (!), assocs, accumArray)
@@ -150,7 +150,7 @@ infixl 2 >|<, >||<
 -- constants
 -- ---------
 
--- we use the dense representation if a table has at least the given number of 
+-- we use the dense representation if a table has at least the given number of
 -- (non-error) elements
 --
 denseMin :: Int
@@ -191,16 +191,16 @@ type ActionErr t = String -> Position -> Either Error t
 -- Meta actions transform the lexeme, position, and a user-defined state; they
 -- may return a lexer, which is then used for accepting the next token (this
 -- is important to implement non-regular behaviour like nested comments)
--- (EXPORTED) 
+-- (EXPORTED)
 --
 type Meta s t = String -> Position -> s -> (Maybe (Either Error t), -- err/tok?
 					    Position,		    -- new pos
 					    s,			    -- state
 					    Maybe (Lexer s t))	    -- lexer?
 
--- tree structure used to represent the lexer table (EXPORTED ABSTRACTLY) 
+-- tree structure used to represent the lexer table (EXPORTED ABSTRACTLY)
 --
---  * each node in the tree corresponds to a state of the lexer; the associated 
+--  * each node in the tree corresponds to a state of the lexer; the associated
 --   actions are those that apply when the corresponding state is reached
 --
 data Lexer s t = Lexer (LexAction s t) (Cont s t)
@@ -241,7 +241,7 @@ type Regexp s t = Lexer s t -> Lexer s t
 epsilon :: Regexp s t
 epsilon  = id
 
--- One character regexp (EXPORTED) 
+-- One character regexp (EXPORTED)
 --
 char   :: Char -> Regexp s t
 char c  = \l -> Lexer NoAction (Sparse (1, c, c) [(c, l)])
@@ -256,14 +256,14 @@ char c  = \l -> Lexer NoAction (Sparse (1, c, c) [(c, l)])
 --
 --  * Note: After the application of the action, the position is advanced
 --	   according to the length of the lexeme.  This implies that normal
---	   actions should not be used in the case where a lexeme might contain 
---	   control characters that imply non-standard changes of the position, 
+--	   actions should not be used in the case where a lexeme might contain
+--	   control characters that imply non-standard changes of the position,
 --	   such as newlines or tabs.
 --
 lexaction      :: Regexp s t -> Action t -> Lexer s t
 lexaction re a  = re `lexmeta` a'
   where
-    a' lexeme pos@(Position fname row col) s = 
+    a' lexeme pos@(Position fname row col) s =
        let col' = col + length lexeme
        in
        col' `seq` case a lexeme pos of
@@ -275,7 +275,7 @@ lexaction re a  = re `lexmeta` a'
 lexactionErr      :: Regexp s t -> ActionErr t -> Lexer s t
 lexactionErr re a  = re `lexmeta` a'
   where
-     a' lexeme pos@(Position fname row col) s = 
+     a' lexeme pos@(Position fname row col) s =
        let col' = col + length lexeme
        in
        col' `seq` (Just (a lexeme pos), (Position fname row col'), s, Nothing)
@@ -308,7 +308,7 @@ joinConts c    c'   = let (bn , cls ) = listify c
 		      in
 		      -- note: `addsBoundsNum' can, at this point, only
 		      --       approx. the number of *non-overlapping* cases;
-		      --       however, the bounds are correct 
+		      --       however, the bounds are correct
 		      --
                       aggregate (addBoundsNum bn bn') (cls ++ cls')
   where
@@ -336,14 +336,14 @@ aggregate bn@(n, lc, hc) cls
 --
 accum :: Eq a => (b -> b -> b) -> [(a, b)] -> [(a, b)]
 accum f []           = []
-accum f ((k, e):kes) = 
+accum f ((k, e):kes) =
   let (ke, kes') = gather k e kes
   in
   ke : accum f kes'
   where
     gather k e []                             = ((k, e), [])
     gather k e (ke'@(k', e'):kes) | k == k'   = gather k (f e e') kes
-				  | otherwise = let 
+				  | otherwise = let
 						  (ke'', kes') = gather k e kes
 						in
 						(ke'', ke':kes')
@@ -363,7 +363,7 @@ ctrlChars  = ['\n', '\r', '\f', '\t']
 --   layout control characters
 --
 ctrlLexer :: Lexer s t
-ctrlLexer  =     
+ctrlLexer  =
        char '\n' `lexmeta` newline
   >||< char '\r' `lexmeta` newline
   >||< char '\v' `lexmeta` newline
@@ -372,7 +372,7 @@ ctrlLexer  =
   where
     newline  _ pos s = (Nothing, retPos pos  , s, Nothing)
     formfeed _ pos s = (Nothing, incPos pos 1, s, Nothing)
-    tab      _ pos s = (Nothing, tabPos pos  , s, Nothing) 
+    tab      _ pos s = (Nothing, tabPos pos  , s, Nothing)
 
 
 -- non-basic combinators
@@ -383,7 +383,7 @@ ctrlLexer  =
 star :: Regexp s t -> Regexp s t -> Regexp s t
 --
 -- The definition used below can be obtained by equational reasoning from this
--- one (which is much easier to understand): 
+-- one (which is much easier to understand):
 --
 --   star re1 re2 = let self = (re1 +> self >|< epsilon) in self +> re2
 --
@@ -394,7 +394,7 @@ star :: Regexp s t -> Regexp s t -> Regexp s t
 -- the functional recursion.
 --
 star re1 re2  = \l -> let self = re1 self >||< re2 l
-		      in 
+		      in
 		      self
 
 -- x `plus` y corresponds to the regular expression x+y (EXPORTED)
@@ -435,7 +435,7 @@ type LexerState s = (String, Position, s)
 
 -- apply a lexer, yielding a token sequence and a list of errors (EXPORTED)
 --
---  * Currently, all errors are fatal; thus, the result is undefined in case of 
+--  * Currently, all errors are fatal; thus, the result is undefined in case of
 --   an error (this changes when error correction is added).
 --
 --  * The final lexer state is returned.
@@ -447,7 +447,7 @@ execLexer :: Lexer s t -> LexerState s -> ([t], LexerState s, [Error])
 --  * the following is moderately tuned
 --
 execLexer l state@([], _, _) = ([], state, [])
-execLexer l state            = 
+execLexer l state            =
   case lexOne l state of
     (Nothing , _ , state') -> execLexer l state'
     (Just res, l', state') -> let (ts, final, allErrs) = execLexer l' state'
@@ -466,8 +466,8 @@ execLexer l state            =
         --
 	lexErr = let (cs, pos@(Position fname row col), s) = state
 	             err = makeError ErrorErr pos
-			     ["Lexical error!", 
-			      "The character " ++ show (head cs) 
+			     ["Lexical error!",
+			      "The character " ++ show (head cs)
 			      ++ " does not fit here; skipping it."]
 		 in
 		 (Just (Left err), l, (tail cs, (Position fname row (col + 1)), s))
@@ -479,15 +479,15 @@ execLexer l state            =
 	--
 	-- we implement the "principle of the longest match" by taking a
 	-- potential result quadruple down (in the last argument); the
-	-- potential result quadruple is updated whenever we pass by an action 
+	-- potential result quadruple is updated whenever we pass by an action
 	-- (different from `NoAction'); initially it is an error result
 	--
 	-- oneLexeme :: Lexer s t
 	--	     -> LexerState
-	--	     -> DList Char 
-	--	     -> (Maybe (Either Error t), Maybe (Lexer s t), 
+	--	     -> DList Char
+	--	     -> (Maybe (Either Error t), Maybe (Lexer s t),
 	--		 LexerState s t)
-	--	     -> (Maybe (Either Error t), Maybe (Lexer s t), 
+	--	     -> (Maybe (Either Error t), Maybe (Lexer s t),
 	--		 LexerState s t)
 	oneLexeme (Lexer a cont) state@(cs, pos, s) csDL last =
 	  let last' = action a csDL state last
@@ -511,9 +511,9 @@ execLexer l state            =
 
 	-- execute the action if present and finalise the current lexeme
 	--
-	action (Action f) csDL (cs, pos, s) last = 
+	action (Action f) csDL (cs, pos, s) last =
 	  case f (closeDL csDL) pos s of
-	    (Nothing, pos', s', l') 
+	    (Nothing, pos', s', l')
 	      | not . null $ cs     -> lexOne (fromMaybe l0 l') (cs, pos', s')
 	    (res    , pos', s', l') -> (res, (fromMaybe l0 l'), (cs, pos', s'))
 	action NoAction csDL state last =

--- a/tools/c2hs/base/syntax/tests/ParsersTest.hs
+++ b/tools/c2hs/base/syntax/tests/ParsersTest.hs
@@ -40,7 +40,7 @@ instance Show CharTok where
 instance Token CharTok
 
 stringToCharToks   :: String -> [CharTok]
-stringToCharToks s  = 
+stringToCharToks s  =
   cts 1 s
   where
     cts _ []     = []
@@ -75,13 +75,13 @@ expr = sep1 (\l a r -> Add l r a) (chara '+') prod
 
 prod = sep1 (\l a r -> Mul l r a) (chara '*') prim
 
-prim =     var 
+prim =     var
        <|> chars '(' -*> expr *-> chars ')'
 
 --var = list1 alphaNum `action` Var
 var = alpha' *> many (:) [] alphaNum `action` \((c, at), cs) -> Var (c:cs) at
       where
-        alpha' = alpha *> meta getName 
+        alpha' = alpha *> meta getName
                  `action` \(CharTok c pos, n) -> (c, newAttrs pos n)
 --               `action` \(CharTok c pos) -> (c, newAttrsOnlyPos pos)
 
@@ -106,7 +106,7 @@ getName (n:ns) = (ns, n)
 
 --vars = many (const (1+)) 0 (char 'x')
 --vars = sep1 (++) (token (CharTok '-' nopos)) ((\c -> [c]) $> char 'x')
---vars = seplist1 (token (CharTok '-' undefined)) (token (CharTok 'x' undefined)) 
+--vars = seplist1 (token (CharTok '-' undefined)) (token (CharTok 'x' undefined))
 
 {-
 testparse    :: String  -> IO ()
@@ -120,7 +120,7 @@ testparse cs  = let (tree, errs) = (execParser expr . stringToCharToks) cs
 
 
 parse    :: Parser [Name] CharTok t -> String  -> PreCST e s (t, [CharTok])
-parse p cs  = 
+parse p cs  =
   do
     nsupp <- getNameSupply
     let ns = names nsupp
@@ -147,5 +147,5 @@ doIt  = let cs = "a+b*(xy+abcdefg)"
           let stringify = concat . map show
           putStrCIO ("`list alpha *> char0 '.'' accepts from `abc.junk' \
                      \the prefix `" ++ stringify (abc ++ [dot])
-                     ++ "',\nand the rest is `" ++ stringify rest 
+                     ++ "',\nand the rest is `" ++ stringify rest
                      ++ "'.\n")

--- a/tools/c2hs/c/C.hs
+++ b/tools/c2hs/c/C.hs
@@ -34,8 +34,8 @@ module C (-- interface to KL for all non-KL modules
           --
           -- stuff from `Common' (reexported)
           --
-          Pos(posOf), 
-          --          
+          Pos(posOf),
+          --
           -- structure tree
           --
           module CAST,
@@ -43,7 +43,7 @@ module C (-- interface to KL for all non-KL modules
           -- attributed structure tree with operations (reexported from
           -- `CAttrs')
           --
-          AttrC, getCHeader, 
+          AttrC, getCHeader,
           CObj(..), CTag(..), CDef(..), lookupDefObjC, lookupDefTagC,
           getDefOfIdentC,
           --
@@ -78,7 +78,7 @@ import C2HSState  (CST, IOMode(..),
 import CAST
 import CParser    (parseC)
 import CPretty
-import CAttrs     (AttrC, attrC, getCHeader, 
+import CAttrs     (AttrC, attrC, getCHeader,
                    CObj(..), CTag(..), CDef(..), lookupDefObjC, lookupDefTagC,
                    getDefOfIdentC)
 import CNames     (nameAnalysis)
@@ -95,7 +95,7 @@ isuffix  = ".i"
 -- given a file name (with suffix), parse that file as a C header and do the
 -- static analysis (collect defined names) (EXPORTED)
 --
---  * currently, lexical and syntactical errors are reported immediately and 
+--  * currently, lexical and syntactical errors are reported immediately and
 --   abort the program; others are reported as part of the fatal error message;
 --   warnings are returned together with the read unit
 --
@@ -134,11 +134,11 @@ loadAttrC fname  = do
                       traceInfoRead fname = putTraceStr tracePhasesSW
                                               ("Attempting to read file `"
                                                ++ fname ++ "'...\n")
-                      traceInfoParse      = putTraceStr tracePhasesSW 
-                                              ("...parsing `" 
+                      traceInfoParse      = putTraceStr tracePhasesSW
+                                              ("...parsing `"
                                                ++ fname ++ "'...\n")
-                      traceInfoNA         = putTraceStr tracePhasesSW 
-                                              ("...name analysis of `" 
+                      traceInfoNA         = putTraceStr tracePhasesSW
+                                              ("...name analysis of `"
                                                ++ fname ++ "'...\n")
                       traceInfoErr        = putTraceStr tracePhasesSW
                                               ("...error(s) detected in `"

--- a/tools/c2hs/c/CAST.hs
+++ b/tools/c2hs/c/CAST.hs
@@ -203,9 +203,9 @@ instance Eq CBlockItem where
 
 
 -- C declaration (K&R A8), structure declaration (K&R A8.3), parameter
--- declaration (K&R A8.6.3), and type name (K&R A8.8) (EXPORTED) 
+-- declaration (K&R A8.6.3), and type name (K&R A8.8) (EXPORTED)
 --
---  * Toplevel declarations (K&R A8): 
+--  * Toplevel declarations (K&R A8):
 --
 --   - they require that the type specifier and qualifier list is not empty,
 --     but gcc allows it and just issues a warning; for the time being, we
@@ -220,8 +220,8 @@ instance Eq CBlockItem where
 --  * Structure declarations (K&R A8.3):
 --
 --   - do not allow storage specifiers;
---   - do not allow initializers; 
---   - require a non-empty declarator-triple list, where abstract declarators 
+--   - do not allow initializers;
+--   - require a non-empty declarator-triple list, where abstract declarators
 --     are not allowed; and
 --   - each of the declarator-triples has to contain either a declarator or a
 --     size expression, or both, ie, it has the form `(Just decl, Nothing,
@@ -231,7 +231,7 @@ instance Eq CBlockItem where
 --  * Parameter declarations (K&R A8.6.3):
 --
 --   - allow neither initializers nor size expressions;
---   - allow at most one declarator triple of the form `(Just declr, Nothing, 
+--   - allow at most one declarator triple of the form `(Just declr, Nothing,
 --     Nothing)' (in case of an empty declarator, the list must be empty); and
 --   - allow abstract declarators.
 --
@@ -239,10 +239,10 @@ instance Eq CBlockItem where
 --
 --   - do not allow storage specifiers;
 --   - allow neither initializers nor size expressions; and
---   - allow at most one declarator triple of the form `(Just declr, Nothing, 
+--   - allow at most one declarator triple of the form `(Just declr, Nothing,
 --     Nothing)' (in case of an empty declarator, the list must be empty),
 --     where the declarator must be abstract, ie, must not contain a declared
---     identifier. 
+--     identifier.
 --
 data CDecl = CDecl [CDeclSpec]          -- type specifier and qualifier
                    [(Maybe CDeclr,      -- declarator (may be omitted)
@@ -380,7 +380,7 @@ instance Eq CTypeQual where
 -- C structure of union declaration (K&R A8.3) (EXPORTED)
 --
 --  * in both case, either the identifier is present or the list must be
---   non-empty 
+--   non-empty
 --
 data CStructUnion = CStruct CStructTag
                             (Maybe Ident)
@@ -420,7 +420,7 @@ instance Eq CEnum where
 --  * We unfold K&R's direct-declarators nonterminal into declarators.  Note
 --   that `*(*x)' is equivalent to `**x'.
 --
---  * Declarators (A8.5) and abstract declarators (A8.8) are represented in the 
+--  * Declarators (A8.5) and abstract declarators (A8.8) are represented in the
 --   same structure.  In the case of a declarator, the identifier in
 --   `CVarDeclr' must be present; in an abstract declarator it misses.
 --   `CVarDeclr Nothing ...' on its own is meaningless, it may only occur as
@@ -432,7 +432,7 @@ instance Eq CEnum where
 --  * Old and new style function definitions are merged into a single case
 --   `CFunDeclr'.  In case of an old style definition, the parameter list is
 --   empty and the variadic flag is `False' (ie, the parameter names are not
---   stored in the tree).  Remember, a new style definition with no parameters 
+--   stored in the tree).  Remember, a new style definition with no parameters
 --   requires a single `void' in the argument list (according to the standard).
 --
 --  * We unfold K&R's parameter-type-list nonterminal into the declarator

--- a/tools/c2hs/c/CAttrs.hs
+++ b/tools/c2hs/c/CAttrs.hs
@@ -25,7 +25,7 @@
 --    - `CObj' in `defObjsAC': The name space of objects, functions, typedef
 --        names, and enum constants.
 --    - `CTag' in `defTagsAC': The name space of tags of structures, unions,
---        and enumerations. 
+--        and enumerations.
 --
 --  * The final state of the names spaces are preserved in the attributed
 --    structure tree.  This allows further fast lookups for globally defined
@@ -102,7 +102,7 @@ data AttrC = AttrC {
 --
 attrC        :: CHeader -> AttrC
 attrC header  = AttrC {
-                    headerAC  = header, 
+                    headerAC  = header,
                     defObjsAC = cObjNS,
                     defTagsAC = cTagNS,
                     shadowsAC = cShadowNS,
@@ -163,13 +163,13 @@ addDefObjC ac ide obj  = let om          = defObjsAC ac
 lookupDefObjC        :: AttrC -> Ident -> Maybe CObj
 lookupDefObjC ac ide  = find (defObjsAC ac) ide
 
--- lookup an identifier in the object name space; if nothing found, try 
+-- lookup an identifier in the object name space; if nothing found, try
 -- whether there is a shadow identifier that matches (EXPORTED)
 --
 --  * the returned identifier is the _real_ identifier of the object
 --
 lookupDefObjCShadow        :: AttrC -> Ident -> Maybe (CObj, Ident)
-lookupDefObjCShadow ac ide  = 
+lookupDefObjCShadow ac ide  =
   case lookupDefObjC ac ide of
     Just obj -> Just (obj, ide)
     Nothing  -> case find (shadowsAC ac) ide of
@@ -180,7 +180,7 @@ lookupDefObjCShadow ac ide  =
 
 -- add another definition to the tag name space (EXPORTED)
 --
---  * if a definition of the same name was already present, it is returned 
+--  * if a definition of the same name was already present, it is returned
 --
 addDefTagC            :: AttrC -> Ident -> CTag -> (AttrC, Maybe CTag)
 addDefTagC ac ide obj  = let tm          = defTagsAC ac
@@ -193,13 +193,13 @@ addDefTagC ac ide obj  = let tm          = defTagsAC ac
 lookupDefTagC        :: AttrC -> Ident -> Maybe CTag
 lookupDefTagC ac ide  = find (defTagsAC ac) ide
 
--- lookup an identifier in the tag name space; if nothing found, try 
+-- lookup an identifier in the tag name space; if nothing found, try
 -- whether there is a shadow identifier that matches (EXPORTED)
 --
 --  * the returned identifier is the _real_ identifier of the tag
 --
 lookupDefTagCShadow        :: AttrC -> Ident -> Maybe (CTag, Ident)
-lookupDefTagCShadow ac ide  = 
+lookupDefTagCShadow ac ide  =
   case lookupDefTagC ac ide of
     Just tag -> Just (tag, ide)
     Nothing  -> case find (shadowsAC ac) ide of
@@ -213,13 +213,13 @@ lookupDefTagCShadow ac ide  =
 -- space (EXPORTED)
 --
 --  * in case of a collisions, a random entry is selected
--- 
+--
 --  * case is not relevant in the prefix and underscores between the prefix and
 --   the stem of an identifier are also dropped
--- 
+--
 applyPrefix           :: AttrC -> String -> AttrC
 applyPrefix ac prefix  =
-  let 
+  let
     shadows    = shadowsAC ac
     names      =    map fst (nameSpaceToList (defObjsAC ac))
                  ++ map fst (nameSpaceToList (defTagsAC ac))
@@ -230,7 +230,7 @@ applyPrefix ac prefix  =
     strip prefix ide = case eat prefix (identToLexeme ide) of
                          Nothing      -> Nothing
                          Just ""      -> Nothing
-                         Just newName -> Just 
+                         Just newName -> Just
                                            (onlyPosIdent (posOf ide) newName,
                                             ide)
     --
@@ -252,13 +252,13 @@ getDefOfIdentC    :: AttrC -> Ident -> CDef
 getDefOfIdentC ac  = getAttr (defsAC ac) . getIdentAttrs
 
 setDefOfIdentC           :: AttrC -> Ident -> CDef -> AttrC
-setDefOfIdentC ac id def  = 
+setDefOfIdentC ac id def  =
   let tot' = setAttr (defsAC ac) (getIdentAttrs id) def
   in
   ac {defsAC = tot'}
 
 updDefOfIdentC            :: AttrC -> Ident -> CDef -> AttrC
-updDefOfIdentC ac id def  = 
+updDefOfIdentC ac id def  =
   let tot' = updAttr (defsAC ac) (getIdentAttrs id) def
   in
   ac {defsAC = tot'}
@@ -339,9 +339,9 @@ instance Eq CDef where
   (TagCD tag1) == (TagCD tag2) = tag1 == tag2
   DontCareCD   == _            = True
   _            == DontCareCD   = True
-  UndefCD      == _            = 
+  UndefCD      == _            =
     interr "CAttrs: Attempt to compare an undefined C definition!"
-  _            == UndefCD      = 
+  _            == UndefCD      =
     interr "CAttrs: Attempt to compare an undefined C definition!"
   _            == _            = False
 

--- a/tools/c2hs/c/CLexer.x
+++ b/tools/c2hs/c/CLexer.x
@@ -26,7 +26,7 @@
 --
 --  language: Haskell 98
 --
---  We assume that the input already went through cpp.  Thus, we do not handle 
+--  We assume that the input already went through cpp.  Thus, we do not handle
 --  comments and preprocessor directives here.  The lexer recognizes all tokens
 --  of ANCI C except those occurring only in function bodies.  It supports the
 --  C99 `restrict' extension: <http://www.lysator.liu.se/c/restrict.html> as
@@ -35,15 +35,15 @@
 --  Comments:
 --
 --  * There is no support for the optional feature of extended characters (see
---    K&R A2.5.2) or the corresponding strings (A2.6). 
+--    K&R A2.5.2) or the corresponding strings (A2.6).
 --
 --  * We add `typedef-name' (K&R 8.9) as a token, as proposed in K&R A13.
 --    However, as these tokens cannot be recognized lexically, but require a
---    context analysis, they are never produced by the lexer, but instead have 
+--    context analysis, they are never produced by the lexer, but instead have
 --    to be introduced in a later phase (by converting the corresponding
---    identifiers). 
+--    identifiers).
 --
---  * We also recognize GNU C `__attribute__', `__extension__', `__const', 
+--  * We also recognize GNU C `__attribute__', `__extension__', `__const',
 --    `__const__', `__inline', `__inline__', `__restrict', and `__restrict__'.
 --
 --  * Any line starting with `#pragma' is ignored.
@@ -116,10 +116,10 @@ $visible  = \ -\127
 
 tokens :-
 
--- whitespace (follows K&R A2.1) 
+-- whitespace (follows K&R A2.1)
 --
 --  * horizontal and vertical tabs, newlines, and form feeds are filter out by
---   `Lexers.ctrlLexer' 
+--   `Lexers.ctrlLexer'
 --
 --  * comments are not handled, as we assume the input already went through cpp
 --
@@ -151,7 +151,7 @@ $white+					;
 --
 $letter($letter|$digit)*	{ \pos len str -> idkwtok (take len str) pos }
 
--- constants (follows K&R A2.5) 
+-- constants (follows K&R A2.5)
 --
 --  * K&R explicit mentions `enumeration-constants'; however, as they are
 --   lexically identifiers, we do not have an extra case for them

--- a/tools/c2hs/c/CNames.hs
+++ b/tools/c2hs/c/CNames.hs
@@ -48,7 +48,7 @@ import CAttrs    (AttrC, CObj(..), CTag(..), CDef(..))
 import CBuiltin  (builtinTypeNames)
 import CTrav     (CT, getCHeaderCT, runCT, enter, enterObjs, leave, leaveObjs,
                   ifCTExc, raiseErrorCTExc, defObj, findTypeObj, findValueObj,
-                  defTag, refersToDef, isTypedef) 
+                  defTag, refersToDef, isTypedef)
 
 
 -- monad and wrapper
@@ -91,7 +91,7 @@ naCHeader  = do
 --
 naCExtDecl :: CExtDecl -> NA ()
 naCExtDecl (CDeclExt decl                        ) = naCDecl decl
-naCExtDecl (CFDefExt (CFunDef specs declr _ _ at)) = 
+naCExtDecl (CFDefExt (CFunDef specs declr _ _ at)) =
   naCDecl $ CDecl specs [(Just declr, Nothing, Nothing)] at
 naCExtDecl (CAsmExt at                           ) = return ()
 
@@ -212,7 +212,7 @@ mapMaybeM_ m (Just a)  = m a >> return ()
 
 declaredTwiceErr              :: Ident -> Position -> NA a
 declaredTwiceErr ide otherPos  =
-  raiseErrorCTExc (posOf ide) 
+  raiseErrorCTExc (posOf ide)
     ["Identifier declared twice!",
-     "The identifier `" ++ identToLexeme ide ++ "' was already declared at " 
+     "The identifier `" ++ identToLexeme ide ++ "' was already declared at "
      ++ show otherPos ++ "."]

--- a/tools/c2hs/c/CParser.y
+++ b/tools/c2hs/c/CParser.y
@@ -20,7 +20,7 @@
 --- DESCRIPTION ---------------------------------------------------------------
 --
 --  Parser for C translation units, which have already been run through the C
---  preprocessor.  
+--  preprocessor.
 --
 --- DOCU ----------------------------------------------------------------------
 --
@@ -423,7 +423,7 @@ selection_statement
   | if '(' expression ')' statement else statement
 	{% withAttrs $1 $ CIf $3 $5 (Just $7) }
 
-  | switch '(' expression ')' statement	
+  | switch '(' expression ')' statement
 	{% withAttrs $1 $ CSwitch $3 $5 }
 
 
@@ -719,9 +719,9 @@ basic_type_specifier
 
 -- A named or anonymous struct, union or enum type along with at least one
 -- storage class and any mix of type qualifiers.
--- 
+--
 --  * summary:
---   [type_qualifier | storage_class | elaborated_type_name]{ 
+--   [type_qualifier | storage_class | elaborated_type_name]{
 --     1 == elaborated_type_name && 1 >= storage_class
 --   }
 --
@@ -997,7 +997,7 @@ typedef_declarator :: { CDeclr }
 typedef_declarator
   -- would be ambiguous as parameter
   : paren_typedef_declarator		{ $1 }
-  
+
   -- not ambiguous as param
   | parameter_typedef_declarator	{ $1 }
 
@@ -1801,8 +1801,8 @@ attr
 
 
 attribute_list :: { () }
-  : attribute						{ () } 
-  | attribute_list ',' attribute			{ () } 
+  : attribute						{ () }
+  | attribute_list ',' attribute			{ () }
 
 
 attribute :: { () }

--- a/tools/c2hs/c/CParserMonad.hs
+++ b/tools/c2hs/c/CParserMonad.hs
@@ -39,8 +39,8 @@
 --
 {-# LANGUAGE CPP #-}
 
-module CParserMonad ( 
-  P, 
+module CParserMonad (
+  P,
   execParser,
   failP,
   getNewName,        -- :: P Name
@@ -74,7 +74,7 @@ data ParseResult a
   = POk !PState a
   | PFailed [String] Position   -- The error message and position
 
-data PState = PState { 
+data PState = PState {
         curPos     :: !Position,        -- position at current input location
         curInput   :: !String,          -- the current input
         prevToken  ::  CToken,          -- the previous token

--- a/tools/c2hs/c/CPretty.hs
+++ b/tools/c2hs/c/CPretty.hs
@@ -108,7 +108,7 @@ prettyDeclr (odeclr, oinit, oexpr) =
 
 instance Pretty CDeclr where
   pretty (CVarDeclr oide                   _) = maybe empty ident oide
-  pretty (CPtrDeclr inds declr             _) = 
+  pretty (CPtrDeclr inds declr             _) =
     let
       oneLevel ind = parens . (hsep (map pretty ind) <+>) . (text "*" <>)
     in
@@ -119,7 +119,7 @@ instance Pretty CDeclr where
     let
       varDoc = if isVariadic then text ", ..." else empty
     in
-    pretty declr 
+    pretty declr
     <+> parens (hsep (punctuate comma (map pretty decls)) <> varDoc)
 
 instance Pretty CInit where

--- a/tools/c2hs/c/CTokens.hs
+++ b/tools/c2hs/c/CTokens.hs
@@ -23,7 +23,7 @@
 --  C Tokens for the C lexer.
 --
 
-module CTokens (CToken(..), GnuCTok(..)) where 
+module CTokens (CToken(..), GnuCTok(..)) where
 
 import Position  (Position(..), Pos(posOf))
 import Idents    (Ident, identToLexeme)
@@ -80,8 +80,8 @@ data CToken = CTokLParen   !Position            -- `('
             | CTokLBrace   !Position            -- `{'
             | CTokRBrace   !Position            --
             | CTokEllipsis !Position            -- `...'
-            | CTokAlignof  !Position            -- `alignof' 
-                                                -- (or `__alignof', 
+            | CTokAlignof  !Position            -- `alignof'
+                                                -- (or `__alignof',
                                                 -- `__alignof__')
             | CTokAsm      !Position            -- `asm'
                                                 -- (or `__asm',
@@ -91,10 +91,10 @@ data CToken = CTokLParen   !Position            -- `('
             | CTokBool     !Position            -- `_Bool'
             | CTokCase     !Position            -- `case'
             | CTokChar     !Position            -- `char'
-            | CTokConst    !Position            -- `const' 
+            | CTokConst    !Position            -- `const'
                                                 -- (or `__const', `__const__')
-            | CTokContinue !Position            -- `continue' 
-            | CTokComplex  !Position            -- `_Complex' 
+            | CTokContinue !Position            -- `continue'
+            | CTokComplex  !Position            -- `_Complex'
             | CTokDefault  !Position            -- `default'
             | CTokDo       !Position            -- `do'
             | CTokDouble   !Position            -- `double'
@@ -107,19 +107,19 @@ data CToken = CTokLParen   !Position            -- `('
             | CTokGoto     !Position            -- `goto'
             | CTokIf       !Position            -- `if'
             | CTokInline   !Position            -- `inline'
-                                                -- (or `__inline', 
+                                                -- (or `__inline',
                                                 -- `__inline__')
             | CTokInt      !Position            -- `int'
             | CTokLong     !Position            -- `long'
             | CTokLabel    !Position            -- `__label__'
             | CTokRegister !Position            -- `register'
             | CTokRestrict !Position            -- `restrict'
-                                                -- (or `__restrict', 
+                                                -- (or `__restrict',
                                                 -- `__restrict__')
             | CTokReturn   !Position            -- `return'
             | CTokShort    !Position            -- `short'
             | CTokSigned   !Position            -- `signed'
-                                                -- (or `__signed', 
+                                                -- (or `__signed',
                                                 -- `__signed__')
             | CTokSizeof   !Position            -- `sizeof'
             | CTokStatic   !Position            -- `static'
@@ -132,7 +132,7 @@ data CToken = CTokLParen   !Position            -- `('
             | CTokUnsigned !Position            -- `unsigned'
             | CTokVoid     !Position            -- `void'
             | CTokVolatile !Position            -- `volatile'
-                                                -- (or `__volatile', 
+                                                -- (or `__volatile',
                                                 -- `__volatile__')
             | CTokWhile    !Position            -- `while'
             | CTokCLit     !Position !Char      -- character constant

--- a/tools/c2hs/c/CTrav.hs
+++ b/tools/c2hs/c/CTrav.hs
@@ -57,7 +57,7 @@
 --- TODO ----------------------------------------------------------------------
 --
 --  * `extractStruct' doesn't account for forward declarations that have no
---   full declaration yet; if `extractStruct' is called on such a declaration, 
+--   full declaration yet; if `extractStruct' is called on such a declaration,
 --   we have a user error, but currently an internal error is raised
 --
 
@@ -98,7 +98,7 @@ import CAttrs     (AttrC, getCHeader, enterNewRangeC, enterNewObjRangeC,
                    lookupDefObjCShadow, addDefTagC, lookupDefTagC,
                    lookupDefTagCShadow, applyPrefix, getDefOfIdentC,
                    setDefOfIdentC, updDefOfIdentC, CObj(..), CTag(..),
-                   CDef(..)) 
+                   CDef(..))
 
 
 -- the C traversal monad
@@ -212,7 +212,7 @@ leaveObjs  = transAttrCCT $ \ac -> (leaveObjRangeC ac, ())
 
 -- enter an object definition into the object name space (EXPORTED)
 --
---  * if a definition of the same name was already present, it is returned 
+--  * if a definition of the same name was already present, it is returned
 --
 defObj         :: Ident -> CObj -> CT s (Maybe CObj)
 defObj ide obj  = transAttrCCT $ \ac -> addDefObjC ac ide obj
@@ -222,7 +222,7 @@ defObj ide obj  = transAttrCCT $ \ac -> addDefObjC ac ide obj
 findObj     :: Ident -> CT s (Maybe CObj)
 findObj ide  = readAttrCCT $ \ac -> lookupDefObjC ac ide
 
--- find a definition in the object name space; if nothing found, try 
+-- find a definition in the object name space; if nothing found, try
 -- whether there is a shadow identifier that matches (EXPORTED)
 --
 findObjShadow     :: Ident -> CT s (Maybe (CObj, Ident))
@@ -241,7 +241,7 @@ findObjShadow ide  = readAttrCCT $ \ac -> lookupDefObjCShadow ac ide
 --   accompanied by a full definition of the enumeration
 --
 defTag         :: Ident -> CTag -> CT s (Maybe CTag)
-defTag ide tag  = 
+defTag ide tag  =
   do
     otag <- transAttrCCT $ \ac -> addDefTagC ac ide tag
     case otag of
@@ -256,7 +256,7 @@ defTag ide tag  =
                            return Nothing               -- transparent for env
   where
     -- compute whether we have the case of a non-conflicting redefined tag
-    -- definition, and if so, return the full definition and the forward 
+    -- definition, and if so, return the full definition and the forward
     -- definition's tag identifier
     --
     --  * the first argument contains the _previous_ definition
@@ -267,16 +267,16 @@ defTag ide tag  =
     --
     --  * there may also be multiple forward definition; if we have two of
     --   them here, one is arbitrarily selected to take the role of the full
-    --   definition 
+    --   definition
     --
     isRefinedOrUse     (StructUnionCT (CStruct _ (Just ide) [] _))
-                   tag@(StructUnionCT (CStruct _ (Just _  ) _  _)) = 
+                   tag@(StructUnionCT (CStruct _ (Just _  ) _  _)) =
       Just (tag, ide)
     isRefinedOrUse tag@(StructUnionCT (CStruct _ (Just _  ) _  _))
-                       (StructUnionCT (CStruct _ (Just ide) [] _)) = 
+                       (StructUnionCT (CStruct _ (Just ide) [] _)) =
       Just (tag, ide)
     isRefinedOrUse tag@(EnumCT        (CEnum (Just _  ) _  _))
-                       (EnumCT        (CEnum (Just ide) [] _))     = 
+                       (EnumCT        (CEnum (Just ide) [] _))     =
       Just (tag, ide)
     isRefinedOrUse _ _                                             = Nothing
 
@@ -285,7 +285,7 @@ defTag ide tag  =
 findTag     :: Ident -> CT s (Maybe CTag)
 findTag ide  = readAttrCCT $ \ac -> lookupDefTagC ac ide
 
--- find an definition in the tag name space; if nothing found, try 
+-- find an definition in the tag name space; if nothing found, try
 -- whether there is a shadow identifier that matches (EXPORTED)
 --
 findTagShadow     :: Ident -> CT s (Maybe (CTag, Ident))
@@ -297,15 +297,15 @@ findTagShadow ide  = readAttrCCT $ \ac -> lookupDefTagCShadow ac ide
 --  * if a new identifier would collides with an existing one, the new one is
 --   discarded, ie, all associations that existed before the transformation
 --   started are still in effect after the transformation
--- 
+--
 applyPrefixToNameSpaces        :: String -> CT s ()
-applyPrefixToNameSpaces prefix  = 
+applyPrefixToNameSpaces prefix  =
   transAttrCCT $ \ac -> (applyPrefix ac prefix, ())
 
 -- definition attribute
 --
 
--- get the definition of an identifier (EXPORTED) 
+-- get the definition of an identifier (EXPORTED)
 --
 --  * the attribute must be defined, ie, a definition must be associated with
 --   the given identifier
@@ -316,21 +316,21 @@ getDefOf ide  = do
                   assert (not . isUndef $ def) $
                     return def
 
--- set the definition of an identifier (EXPORTED) 
+-- set the definition of an identifier (EXPORTED)
 --
 refersToDef         :: Ident -> CDef -> CT s ()
 refersToDef ide def  = transAttrCCT $ \akl -> (setDefOfIdentC akl ide def, ())
 
--- update the definition of an identifier (EXPORTED) 
+-- update the definition of an identifier (EXPORTED)
 --
 refersToNewDef         :: Ident -> CDef -> CT s ()
-refersToNewDef ide def  = 
+refersToNewDef ide def  =
   transAttrCCT $ \akl -> (updDefOfIdentC akl ide def, ())
 
 -- get the declarator of an identifier (EXPORTED)
 --
 getDeclOf     :: Ident -> CT s CDecl
-getDeclOf ide  = 
+getDeclOf ide  =
   do
     traceEnter
     def <- getDefOf ide
@@ -352,12 +352,12 @@ getDeclOf ide  =
                      -- if the latter ever becomes necessary, we have to
                      -- change the representation of builtins and give them
                      -- some dummy declarator
-    traceEnter  = traceCTrav $ 
-                    "Entering `getDeclOf' for `" ++ identToLexeme ide 
+    traceEnter  = traceCTrav $
+                    "Entering `getDeclOf' for `" ++ identToLexeme ide
                     ++ "'...\n"
-    traceTypeCO = traceCTrav $ 
+    traceTypeCO = traceCTrav $
                     "...found a type object.\n"
-    traceObjCO  = traceCTrav $ 
+    traceObjCO  = traceCTrav $
                     "...found a vanilla object.\n"
 
 
@@ -370,10 +370,10 @@ getDeclOf ide  =
 --  * if the second argument is `True', use `findObjShadow'
 --
 findTypeObjMaybe                :: Ident -> Bool -> CT s (Maybe (CObj, Ident))
-findTypeObjMaybe ide useShadows  = 
+findTypeObjMaybe ide useShadows  =
   do
-    oobj <- if useShadows 
-            then findObjShadow ide 
+    oobj <- if useShadows
+            then findObjShadow ide
             else liftM (fmap (\obj -> (obj, ide))) $ findObj ide
     case oobj of
       Just obj@(TypeCO _ , _) -> return $ Just obj
@@ -399,10 +399,10 @@ findTypeObj ide useShadows  = do
 --  * if the second argument is `True', use `findObjShadow'
 --
 findValueObj                :: Ident -> Bool -> CT s (CObj, Ident)
-findValueObj ide useShadows  = 
+findValueObj ide useShadows  =
   do
-    oobj <- if useShadows 
-            then findObjShadow ide 
+    oobj <- if useShadows
+            then findObjShadow ide
             else liftM (fmap (\obj -> (obj, ide))) $ findObj ide
     case oobj of
       Just obj@(ObjCO  _  , _) -> return obj
@@ -411,12 +411,12 @@ findValueObj ide useShadows  =
       Nothing                  -> unknownObjErr ide
 
 -- find a function in the object name space; raises an error and exception if
--- the identifier is not defined (EXPORTED) 
+-- the identifier is not defined (EXPORTED)
 --
 --  * if the second argument is `True', use `findObjShadow'
 --
 findFunObj               :: Ident -> Bool -> CT s  (CObj, Ident)
-findFunObj ide useShadows = 
+findFunObj ide useShadows =
   do
     (obj, ide') <- findValueObj ide useShadows
     case obj of
@@ -433,11 +433,11 @@ findFunObj ide useShadows =
 -- test if this is a type definition specification (EXPORTED)
 --
 isTypedef                   :: CDecl -> Bool
-isTypedef (CDecl specs _ _)  = 
+isTypedef (CDecl specs _ _)  =
   not . null $ [() | CStorageSpec (CTypedef _) <- specs]
 
 -- discard all declarators but the one declaring the given identifier
--- (EXPORTED) 
+-- (EXPORTED)
 --
 --  * the declaration must contain the identifier
 --
@@ -459,7 +459,7 @@ ide `simplifyDecl` (CDecl specs declrs at) =
 --  * the declaration must contain the identifier
 --
 declrFromDecl            :: Ident -> CDecl -> CDeclr
-ide `declrFromDecl` decl  = 
+ide `declrFromDecl` decl  =
   let CDecl _ [(Just declr, _, _)] _ = ide `simplifyDecl` decl
   in
   declr
@@ -470,17 +470,17 @@ declrNamed             :: CDeclr -> Ident -> Bool
 declr `declrNamed` ide  = declrName declr == Just ide
 
 -- get the declarator of a declaration that has at most one declarator
--- (EXPORTED) 
+-- (EXPORTED)
 --
 declaredDeclr                              :: CDecl -> Maybe CDeclr
 declaredDeclr (CDecl _ []               _)  = Nothing
 declaredDeclr (CDecl _ [(odeclr, _, _)] _)  = odeclr
-declaredDeclr decl                          = 
+declaredDeclr decl                          =
   interr $ "CTrav.declaredDeclr: Too many declarators!\n\
            \  Declaration at " ++ show (posOf decl)
 
 -- get the name declared by a declaration that has exactly one declarator
--- (EXPORTED) 
+-- (EXPORTED)
 --
 declaredName      :: CDecl -> Maybe Ident
 declaredName decl  = declaredDeclr decl >>= declrName
@@ -497,7 +497,7 @@ structMembers (CStruct tag _ members _) = (concat . map expandDecl $ members,
 -- declarators, eg, `int x, y;' becomes `int x; int y;' (EXPORTED)
 --
 expandDecl                        :: CDecl -> [CDecl]
-expandDecl (CDecl specs decls at)  = 
+expandDecl (CDecl specs decls at)  =
   map (\decl -> CDecl specs [decl] at) decls
 
 -- get a struct's name (EXPORTED)
@@ -555,7 +555,7 @@ isArrDeclr _                                = False
 --
 dropPtrDeclr                                          :: CDeclr -> CDeclr
 dropPtrDeclr (CPtrDeclr qs declr@(CVarDeclr _ _) ats)  = declr
-dropPtrDeclr (CPtrDeclr qs  declr                ats)  = 
+dropPtrDeclr (CPtrDeclr qs  declr                ats)  =
   let declr' = dropPtrDeclr declr
   in
   CPtrDeclr qs declr' ats
@@ -600,7 +600,7 @@ structFromDecl pos (CDecl specs _ _)  =
 
 -- extracts the arguments from a function declaration (must be a unique
 -- declarator) and constructs a declaration for the result of the function
--- (EXPORTED) 
+-- (EXPORTED)
 --
 --  * the boolean result indicates whether the function is variadic
 --
@@ -612,9 +612,9 @@ funResultAndArgs (CDecl specs [(Just declr, _, _)] _) =
   in
   (args, result, variadic)
   where
-    funArgs (CFunDeclr var@(CVarDeclr _ _) args variadic  _) = 
+    funArgs (CFunDeclr var@(CVarDeclr _ _) args variadic  _) =
       (args, var, variadic)
-    funArgs (CPtrDeclr qs declr                          at) = 
+    funArgs (CPtrDeclr qs declr                          at) =
       let (args, declr', variadic) = funArgs declr
       in
       (args, CPtrDeclr qs declr' at, variadic)
@@ -643,10 +643,10 @@ funResultAndArgs (CDecl specs [(Just declr, _, _)] _) =
 --
 chaseDecl         :: Ident -> Bool -> CT s CDecl
 --
---  * cycles are no issue, as they cannot occur in a correct C header (we would 
+--  * cycles are no issue, as they cannot occur in a correct C header (we would
 --   have spotted the problem during name analysis)
 --
-chaseDecl ide ind  = 
+chaseDecl ide ind  =
   do
     traceEnter
     cdecl     <- getDeclOf ide
@@ -655,9 +655,9 @@ chaseDecl ide ind  =
       Just    (ide', ind') -> chaseDecl ide' ind'
       Nothing              -> return sdecl
   where
-    traceEnter = traceCTrav $ 
-                   "Entering `chaseDecl' for `" ++ identToLexeme ide 
-                   ++ "' " ++ (if ind then "" else "not ") 
+    traceEnter = traceCTrav $
+                   "Entering `chaseDecl' for `" ++ identToLexeme ide
+                   ++ "' " ++ (if ind then "" else "not ")
                    ++ "following indirections...\n"
 
 -- find type object in object name space and then chase it (EXPORTED)
@@ -705,7 +705,7 @@ checkForOneAliasName decl  = fmap fst $ extractAlias decl False
 lookupEnum               :: Ident -> Bool -> CT s CEnum
 lookupEnum ide useShadows =
   do
-    otag <- if useShadows 
+    otag <- if useShadows
             then liftM (fmap fst) $ findTagShadow ide
             else findTag ide
     case otag of
@@ -737,7 +737,7 @@ lookupStructUnion ide ind useShadows
   | ind       = chase
   | otherwise =
     do
-      otag <- if useShadows 
+      otag <- if useShadows
               then liftM (fmap fst) $ findTagShadow ide
               else findTag ide
       maybe chase (extractStruct (posOf ide)) otag  -- `chase' if `Nothing'
@@ -760,10 +760,10 @@ lookupDeclOrTag                :: Ident -> Bool -> CT s (Either CDecl CTag)
 lookupDeclOrTag ide useShadows  = do
   oobj <- findTypeObjMaybe ide useShadows
   case oobj of
-    Just (_, ide) -> liftM Left $ findAndChaseDecl ide False False 
+    Just (_, ide) -> liftM Left $ findAndChaseDecl ide False False
                                                    -- already did check shadows
     Nothing       -> do
-                       otag <- if useShadows 
+                       otag <- if useShadows
                                then liftM (fmap fst) $ findTagShadow ide
                                else findTag ide
                        case otag of
@@ -789,7 +789,7 @@ lookupDeclOrTag ide useShadows  = do
 --
 --  * if `ind = True', the alias may be via an indirection
 --
---  * if `ind = True' and the alias is _not_ over an indirection, yield `True'; 
+--  * if `ind = True' and the alias is _not_ over an indirection, yield `True';
 --   otherwise `False' (ie, the ability to hop over an indirection is consumed)
 --
 --  * this may be an anonymous declaration, ie, the name in `CVarDeclr' may be
@@ -848,7 +848,7 @@ assertFunDeclr pos            (CPtrDeclr _ declr             _)        =
   assertFunDeclr pos declr
 assertFunDeclr pos            (CArrDeclr declr           _ _ _)        =
   assertFunDeclr pos declr
-assertFunDeclr pos _                                                 = 
+assertFunDeclr pos _                                                 =
   funExpectedErr pos
 
 -- raise an error if the given tag defines an enumeration, but does not fully
@@ -869,20 +869,20 @@ traceCTrav  = putTraceStr traceCTravSW
 
 unknownObjErr     :: Ident -> CT s a
 unknownObjErr ide  =
-  raiseErrorCTExc (posOf ide) 
+  raiseErrorCTExc (posOf ide)
     ["Unknown identifier!",
      "Cannot find a definition for `" ++ identToLexeme ide ++ "' in the \
      \header file."]
 
 typedefExpectedErr      :: Ident -> CT s a
-typedefExpectedErr ide  =   
-  raiseErrorCTExc (posOf ide) 
+typedefExpectedErr ide  =
+  raiseErrorCTExc (posOf ide)
     ["Expected type definition!",
      "The identifier `" ++ identToLexeme ide ++ "' needs to be a C type name."]
 
 unexpectedTypedefErr     :: Position -> CT s a
-unexpectedTypedefErr pos  =   
-  raiseErrorCTExc pos 
+unexpectedTypedefErr pos  =
+  raiseErrorCTExc pos
     ["Unexpected type name!",
      "An object, function, or enum constant is required here."]
 
@@ -893,14 +893,14 @@ illegalFunResultErr pos  =
 
 funExpectedErr      :: Position -> CT s a
 funExpectedErr pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Function expected!",
      "A function is needed here, but this declarator does not declare",
      "a function."]
 
 enumExpectedErr     :: Ident -> CT s a
 enumExpectedErr ide  =
-  raiseErrorCTExc (posOf ide) 
+  raiseErrorCTExc (posOf ide)
     ["Expected enum!",
      "Expected `" ++ identToLexeme ide ++ "' to denote an enum; instead found",
      "a struct, union, or object."]
@@ -913,6 +913,6 @@ structExpectedErr pos  =
 
 enumForwardErr     :: Position -> CT s a
 enumForwardErr pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Forward definition of enumeration!",
      "ANSI C does not permit forward definitions of enumerations!"]

--- a/tools/c2hs/chs/CHS.hs
+++ b/tools/c2hs/chs/CHS.hs
@@ -30,7 +30,7 @@
 --  the hook.  The parser checks the version of the `.chi' file, but does not
 --  otherwise attempt to interpret its contents.  This is only done during
 --  generation of the binding module.  The first line of a .chi file has the
---  form 
+--  form
 --
 --    C->Haskell Interface Version <version>
 --
@@ -75,7 +75,7 @@
 --  alias    -> `underscoreToCase'
 --            | ident `as' ident
 --  ptrkind  -> [`foreign' | `stable' ] ['newtype' | '->' ident]
---  
+--
 --  If `underscoreToCase' occurs in a translation table, it must be the first
 --  entry.
 --
@@ -92,7 +92,7 @@ module CHS (CHSModule(..), CHSFrag(..), CHSHook(..), CHSTrans(..), CHSParm(..),
             skipToLangPragma, hasCPP,
             loadCHS, dumpCHS, hssuffix, chssuffix, loadAllCHI, loadCHI, dumpCHI,
             chisuffix, showCHSParm)
-where 
+where
 
 -- standard libraries
 import Data.Char         (isSpace, toUpper, toLower)
@@ -105,9 +105,9 @@ import Errors    (interr)
 import Idents    (Ident, identToLexeme, onlyPosIdent)
 
 -- C->Haskell
-import C2HSState (CST, nop, doesFileExistCIO, readFileCIO, writeFileCIO, getId, 
-                  getSwitch, chiPathSB, catchExc, throwExc, raiseError, 
-                  fatal, errorsPresent, showErrors, Traces(..), putTraceStr) 
+import C2HSState (CST, nop, doesFileExistCIO, readFileCIO, writeFileCIO, getId,
+                  getSwitch, chiPathSB, catchExc, throwExc, raiseError,
+                  fatal, errorsPresent, showErrors, Traces(..), putTraceStr)
 
 -- friends
 import CHSLexer  (CHSToken(..), lexCHS)
@@ -127,7 +127,7 @@ data CHSModule = CHSModule [CHSFrag]
 --   code)
 --
 --  * `CHSHook' are binding hooks, which are being replaced by Haskell code by
---   `GenBind.expandHooks' 
+--   `GenBind.expandHooks'
 --
 --  * `CHSCPP' and `CHSC' are fragments of C code that are being removed when
 --   generating the custom C header in `GenHeader.genHeader'
@@ -197,7 +197,7 @@ data CHSHook = CHSImport  Bool                  -- qualified?
                           Position
              | CHSField   CHSAccess             -- access type
                           CHSAPath              -- access path
-                          Position 
+                          Position
              | CHSPointer Bool                  -- explicit '*' in hook
                           Ident                 -- C pointer name
                           (Maybe Ident)         -- Haskell name
@@ -223,28 +223,28 @@ instance Pos CHSHook where
   posOf (CHSClass   _ _ _         pos) = pos
 
 -- two hooks are equal if they have the same Haskell name and reference the
--- same C object 
+-- same C object
 --
 instance Eq CHSHook where
-  (CHSImport qual1 ide1 _      _) == (CHSImport qual2 ide2 _      _) =    
+  (CHSImport qual1 ide1 _      _) == (CHSImport qual2 ide2 _      _) =
     qual1 == qual2 && ide1 == ide2
   (CHSContext olib1 opref1 olock1 _   ) ==
-    (CHSContext olib2 opref2 olock2 _   ) =    
+    (CHSContext olib2 opref2 olock2 _   ) =
     olib1 == olib1 && opref1 == opref2 && olock1 == olock2
-  (CHSType ide1                _) == (CHSType ide2                _) = 
+  (CHSType ide1                _) == (CHSType ide2                _) =
     ide1 == ide2
-  (CHSSizeof ide1              _) == (CHSSizeof ide2              _) = 
+  (CHSSizeof ide1              _) == (CHSSizeof ide2              _) =
     ide1 == ide2
-  (CHSEnum ide1 oalias1 _ _ _  _) == (CHSEnum ide2 oalias2 _ _ _  _) = 
+  (CHSEnum ide1 oalias1 _ _ _  _) == (CHSEnum ide2 oalias2 _ _ _  _) =
     oalias1 == oalias2 && ide1 == ide2
-  (CHSCall _ _ _ ide1 oalias1    _) == (CHSCall _ _ _ ide2 oalias2    _) = 
+  (CHSCall _ _ _ ide1 oalias1    _) == (CHSCall _ _ _ ide2 oalias2    _) =
     oalias1 == oalias2 && ide1 == ide2
-  (CHSFun  _ _ _ ide1 oalias1 _ _ _ _) 
-                                  == (CHSFun _ _ _ ide2 oalias2 _ _ _ _) = 
+  (CHSFun  _ _ _ ide1 oalias1 _ _ _ _)
+                                  == (CHSFun _ _ _ ide2 oalias2 _ _ _ _) =
     oalias1 == oalias2 && ide1 == ide2
-  (CHSField acc1 path1         _) == (CHSField acc2 path2         _) =    
+  (CHSField acc1 path1         _) == (CHSField acc2 path2         _) =
     acc1 == acc2 && path1 == path2
-  (CHSPointer _ ide1 oalias1 _ _ _ _) 
+  (CHSPointer _ ide1 oalias1 _ _ _ _)
                                   == (CHSPointer _ ide2 oalias2 _ _ _ _) =
     ide1 == ide2 && oalias1 == oalias2
   (CHSClass _ ide1 _           _) == (CHSClass _ ide2 _           _) =
@@ -301,11 +301,11 @@ instance Show CHSPtrType where
   show CHSStablePtr      = "StablePtr"
 
 instance Read CHSPtrType where
-  readsPrec _ (                            'P':'t':'r':rest) = 
+  readsPrec _ (                            'P':'t':'r':rest) =
     [(CHSPtr, rest)]
-  readsPrec _ ('F':'o':'r':'e':'i':'g':'n':'P':'t':'r':rest) = 
+  readsPrec _ ('F':'o':'r':'e':'i':'g':'n':'P':'t':'r':rest) =
     [(CHSForeignPtr, rest)]
-  readsPrec _ ('S':'t':'a':'b':'l':'e'    :'P':'t':'r':rest) = 
+  readsPrec _ ('S':'t':'a':'b':'l':'e'    :'P':'t':'r':rest) =
     [(CHSStablePtr, rest)]
   readsPrec p (c:cs)
     | isSpace c                                              = readsPrec p cs
@@ -343,7 +343,7 @@ loadCHS fname = do
    -- parse
    --
    traceInfoRead fname
-   contents <- readFileCIO fname 
+   contents <- readFileCIO fname
    traceInfoParse
    mod <- parseCHSModule (Position fname 1 1) contents
 
@@ -364,8 +364,8 @@ loadCHS fname = do
     traceInfoRead fname = putTraceStr tracePhasesSW
                             ("Attempting to read file `"
                              ++ fname ++ "'...\n")
-    traceInfoParse      = putTraceStr tracePhasesSW 
-                            ("...parsing `" 
+    traceInfoParse      = putTraceStr tracePhasesSW
+                            ("...parsing `"
                              ++ fname ++ "'...\n")
     traceInfoErr        = putTraceStr tracePhasesSW
                             ("...error(s) detected in `"
@@ -374,11 +374,11 @@ loadCHS fname = do
                             ("...successfully loaded `"
                              ++ fname ++ "'.\n")
 
--- given a file name (no suffix) and a CHS module, the module is printed 
+-- given a file name (no suffix) and a CHS module, the module is printed
 -- into that file (EXPORTED)
--- 
+--
 --  * the module can be flagged as being pure Haskell
--- 
+--
 --  * the correct suffix will automagically be appended
 --
 dumpCHS                       :: String -> CHSModule -> Bool -> CST s ()
@@ -391,7 +391,7 @@ dumpCHS fname mod pureHaskell  =
     writeFileCIO (fname ++ suffix) (contents version kind)
   where
     contents version kind | hasCPP mod = showCHSModule mod pureHaskell
-                          | otherwise = 
+                          | otherwise =
       "-- GENERATED by " ++ version ++ " " ++ kind ++ "\n\
       \-- Edit the ORIGINAL .chs file instead!\n\n"
       ++ showCHSModule mod pureHaskell
@@ -408,7 +408,7 @@ data LineState = Emit           -- emit LINE pragma if next frag is Haskell
 --  * if the second argument is `True', all fragments must contain Haskell code
 --
 showCHSModule                               :: CHSModule -> Bool -> String
-showCHSModule (CHSModule frags) pureHaskell  = 
+showCHSModule (CHSModule frags) pureHaskell  =
   showFrags pureHaskell Emit frags []
   where
     -- the second argument indicates whether the next fragment (if it is
@@ -418,28 +418,28 @@ showCHSModule (CHSModule frags) pureHaskell  =
     --
     showFrags :: Bool -> LineState -> [CHSFrag] -> ShowS
     showFrags _      _     []                           = id
-    showFrags pureHs state (CHSVerb s      pos : frags) = 
+    showFrags pureHs state (CHSVerb s      pos : frags) =
       let
         (Position fname line _) = pos
         generated        = isBuiltinPos pos
-        emitNow          = state == Emit || 
+        emitNow          = state == Emit ||
                            (state == Wait && not (null s) && nlStart)
         nlStart          = head s == '\n'
         nextState        = if generated then Wait else NoLine
       in
         (if emitNow then
-           showString ("\n{-# LINE " ++ show (line `max` 0) ++ " " ++ 
+           showString ("\n{-# LINE " ++ show (line `max` 0) ++ " " ++
                        show fname ++ " #-}" ++
                        (if nlStart then "" else "\n"))
          else id)
       . showString s
       . showFrags pureHs nextState frags
-    showFrags False  _     (CHSHook hook       : frags) =   
-        showString "{#" 
+    showFrags False  _     (CHSHook hook       : frags) =
+        showString "{#"
       . showCHSHook hook
       . showString "#}"
       . showFrags False Wait frags
-    showFrags False  _     (CHSCPP  s    _     : frags) =   
+    showFrags False  _     (CHSCPP  s    _     : frags) =
         showChar '#'
       . showString s
 --      . showChar '\n'
@@ -464,11 +464,11 @@ showCHSModule (CHSModule frags) pureHaskell  =
       interr "showCHSFrag: Illegal hook, cpp directive, or inline C code!"
 
 showCHSHook :: CHSHook -> ShowS
-showCHSHook (CHSImport isQual ide _ _) =   
+showCHSHook (CHSImport isQual ide _ _) =
     showString "import "
   . (if isQual then showString "qualified " else id)
   . showCHSIdent ide
-showCHSHook (CHSContext olib oprefix olock _) =   
+showCHSHook (CHSContext olib oprefix olock _) =
     showString "context "
   . (case olib of
        Nothing  -> showString ""
@@ -477,28 +477,28 @@ showCHSHook (CHSContext olib oprefix olock _) =
   . (case olock of
        Nothing  -> showString ""
        Just lock -> showString "lock = " . showString lock . showString " ")
-showCHSHook (CHSType ide _) =   
+showCHSHook (CHSType ide _) =
     showString "type "
   . showCHSIdent ide
-showCHSHook (CHSSizeof ide _) =   
+showCHSHook (CHSSizeof ide _) =
     showString "sizeof "
   . showCHSIdent ide
-showCHSHook (CHSEnum ide oalias trans oprefix derive _) =   
+showCHSHook (CHSEnum ide oalias trans oprefix derive _) =
     showString "enum "
   . showIdAlias ide oalias
   . showCHSTrans trans
   . showPrefix oprefix True
   . if null derive then id else showString $
-      "deriving (" 
+      "deriving ("
       ++ concat (intersperse ", " (map identToLexeme derive))
       ++ ") "
-showCHSHook (CHSCall isPure isUns isNol ide oalias _) =   
+showCHSHook (CHSCall isPure isUns isNol ide oalias _) =
     showString "call "
   . (if isPure then showString "pure " else id)
   . (if isUns then showString "unsafe " else id)
   . (if isNol then showString "nolock " else id)
   . showIdAlias ide oalias
-showCHSHook (CHSFun isPure isUns isNol ide oalias octxt parms parm _) =   
+showCHSHook (CHSFun isPure isUns isNol ide oalias octxt parms parm _) =
     showString "fun "
   . (if isPure then showString "pure " else id)
   . (if isUns then showString "unsafe " else id)
@@ -511,7 +511,7 @@ showCHSHook (CHSFun isPure isUns isNol ide oalias octxt parms parm _) =
   . foldr (.) id (intersperse (showString ", ") (map showCHSParm parms))
   . showString "} -> "
   . showCHSParm parm
-showCHSHook (CHSField acc path _) =   
+showCHSHook (CHSField acc path _) =
     (case acc of
        CHSGet -> showString "get "
        CHSSet -> showString "set ")
@@ -525,10 +525,10 @@ showCHSHook (CHSPointer star ide oalias ptrType isNewtype oRefType _) =
        CHSStablePtr  -> showString " stable"
        _             -> showString "")
   . (case (isNewtype, oRefType) of
-       (True , _       ) -> showString " newtype" 
+       (True , _       ) -> showString " newtype"
        (False, Just ide) -> showString " -> " . showCHSIdent ide
        (False, Nothing ) -> showString "")
-showCHSHook (CHSClass oclassIde classIde typeIde _) =   
+showCHSHook (CHSClass oclassIde classIde typeIde _) =
     showString "class "
   . (case oclassIde of
        Nothing       -> showString ""
@@ -539,9 +539,9 @@ showCHSHook (CHSClass oclassIde classIde typeIde _) =
 
 showPrefix                        :: Maybe String -> Bool -> ShowS
 showPrefix Nothing       _         = showString ""
-showPrefix (Just prefix) withWith  =   maybeWith 
-                                     . showString "prefix = " 
-                                     . showString prefix 
+showPrefix (Just prefix) withWith  =   maybeWith
+                                     . showString "prefix = "
+                                     . showString prefix
                                      . showString " "
   where
     maybeWith = if withWith then showString "with " else id
@@ -572,7 +572,7 @@ showCHSParm (CHSParm oimMarsh hsTyStr twoCVals oomMarsh _)  =
     showHsVerb str = showChar '`' . showString str . showChar '\''
 
 showCHSTrans                          :: CHSTrans -> ShowS
-showCHSTrans (CHSTrans _2Case assocs)  =   
+showCHSTrans (CHSTrans _2Case assocs)  =
     showString "{"
   . (if _2Case then showString ("underscoreToCase" ++ maybeComma) else id)
   . foldr (.) id (intersperse (showString ", ") (map showAssoc assocs))
@@ -637,7 +637,7 @@ loadCHI fname  = do
                    -- search for .chi files
                    --
                    paths <- getSwitch chiPathSB
-                   let fullnames = [path ++ '/':fname ++ chisuffix | 
+                   let fullnames = [path ++ '/':fname ++ chisuffix |
                                     path <- paths]
                    fullname <- findFirst fullnames
                      (fatal $ fname++chisuffix++" not found in:\n"++
@@ -662,11 +662,11 @@ loadCHI fname  = do
                    (major, minor) <- case majorMinor versline' of
                                        Nothing     -> errorCHICorrupt fname
                                        Just majMin -> return majMin
-                     
+
                    (version, _, _) <- getId
                    let Just (myMajor, myMinor) = majorMinor version
                    when (major /= myMajor || minor /= myMinor) $
-                     errorCHIVersion fname 
+                     errorCHIVersion fname
                        (major ++ "." ++ minor) (myMajor ++ "." ++ myMinor)
 
                    -- finalize
@@ -677,8 +677,8 @@ loadCHI fname  = do
                     traceInfoRead fname = putTraceStr tracePhasesSW
                                             ("Attempting to read file `"
                                              ++ fname ++ "'...\n")
-                    traceInfoVersion    = putTraceStr tracePhasesSW 
-                                            ("...checking version `" 
+                    traceInfoVersion    = putTraceStr tracePhasesSW
+                                            ("...checking version `"
                                              ++ fname ++ "'...\n")
                     traceInfoOK         = putTraceStr tracePhasesSW
                                             ("...successfully loaded `"
@@ -687,11 +687,11 @@ loadCHI fname  = do
                     findFirst (p:aths)  err =  do
                       e <- doesFileExistCIO p
                       if e then return p else findFirst aths err
-                 
 
--- given a file name (no suffix) and a CHI file, the information is printed 
+
+-- given a file name (no suffix) and a CHI file, the information is printed
 -- into that file (EXPORTED)
--- 
+--
 --  * the correct suffix will automagically be appended
 --
 dumpCHI                :: String -> String -> CST s ()
@@ -764,7 +764,7 @@ parseFrags toks  = do
     parseFrags0 (CHSTokLine    pos  :toks) = do
                                                frags <- parseFrags toks
                                                return $ CHSLine pos : frags
-    parseFrags0 (CHSTokC       pos s:toks) = parseC       pos s      toks 
+    parseFrags0 (CHSTokC       pos s:toks) = parseC       pos s      toks
     parseFrags0 (CHSTokImport  pos  :toks) = parseImport  pos        toks
     parseFrags0 (CHSTokContext pos  :toks) = parseContext pos        toks
     parseFrags0 (CHSTokType    pos  :toks) = parseType    pos        toks
@@ -787,7 +787,7 @@ parseFrags toks  = do
     contFrags      (_                :toks) = contFrags  toks
 
 parseC :: Position -> String -> [CHSToken] -> CST s [CHSFrag]
-parseC pos s toks = 
+parseC pos s toks =
   do
     frags <- collectCtrlAndC toks
     return $ CHSC s pos : frags
@@ -802,7 +802,7 @@ parseC pos s toks =
 
 parseImport :: Position -> [CHSToken] -> CST s [CHSFrag]
 parseImport pos toks = do
-  (qual, modid, toks') <- 
+  (qual, modid, toks') <-
     case toks of
       CHSTokIdent _ ide                :toks ->
         let (ide', toks') = rebuildModuleId ide toks
@@ -819,7 +819,7 @@ parseImport pos toks = do
 -- Qualified module names do not get lexed as a single token so we need to
 -- reconstruct it from a sequence of identifier and dot tokens.
 --
-rebuildModuleId ide (CHSTokDot _ : CHSTokIdent _ ide' : toks) = 
+rebuildModuleId ide (CHSTokDot _ : CHSTokIdent _ ide' : toks) =
   let catIdent ide ide' = onlyPosIdent (posOf ide)  --FIXME: unpleasant hack
                             (identToLexeme ide ++ '.' : identToLexeme ide')
    in rebuildModuleId (catIdent ide ide') toks
@@ -873,7 +873,7 @@ parseEnum pos (CHSTokIdent _ ide:toks) =
 parseEnum _ toks = syntaxError toks
 
 parseCall          :: Position -> [CHSToken] -> CST s [CHSFrag]
-parseCall pos toks  = 
+parseCall pos toks  =
   do
     (isPure  , toks ) <- parseIsPure          toks
     (isUnsafe, toks ) <- parseIsUnsafe        toks
@@ -882,11 +882,11 @@ parseCall pos toks  =
     (oalias  , toks ) <- parseOptAs ide False toks
     toks              <- parseEndHook         toks
     frags             <- parseFrags           toks
-    return $ 
+    return $
       CHSHook (CHSCall isPure isUnsafe isNolock ide (norm ide oalias) pos) : frags
 
 parseFun          :: Position -> [CHSToken] -> CST s [CHSFrag]
-parseFun pos toks  = 
+parseFun pos toks  =
   do
     (isPure  , toks' ) <- parseIsPure          toks
     (isUnsafe, toks'2) <- parseIsUnsafe        toks'
@@ -898,8 +898,8 @@ parseFun pos toks  =
     (parm    , toks'8) <- parseParm            toks'7
     toks'9             <- parseEndHook         toks'8
     frags              <- parseFrags           toks'9
-    return $ 
-      CHSHook 
+    return $
+      CHSHook
         (CHSFun isPure isUnsafe isNolock ide (norm ide oalias) octxt parms parm pos) :
       frags
   where
@@ -908,11 +908,11 @@ parseFun pos toks  =
     parseOptContext toks                                      =
       return (Nothing  , toks)
     --
-    parseParms (CHSTokLBrace _:CHSTokRBrace _:CHSTokArrow _:toks) = 
+    parseParms (CHSTokLBrace _:CHSTokRBrace _:CHSTokArrow _:toks) =
       return ([], toks)
-    parseParms (CHSTokLBrace _                             :toks) = 
+    parseParms (CHSTokLBrace _                             :toks) =
       parseParms' (CHSTokComma nopos:toks)
-    parseParms                                              toks  = 
+    parseParms                                              toks  =
       syntaxError toks
     --
     parseParms' (CHSTokRBrace _:CHSTokArrow _:toks) = return ([], toks)
@@ -947,22 +947,22 @@ parseParm :: [CHSToken] -> CST s (CHSParm, [CHSToken])
 parseParm toks =
   do
     (oimMarsh, toks' ) <- parseOptMarsh toks
-    (hsTyStr, twoCVals, pos, toks'2) <- 
+    (hsTyStr, twoCVals, pos, toks'2) <-
       case toks' of
-        (CHSTokHSVerb pos hsTyStr:CHSTokAmp _:toks'2) -> 
+        (CHSTokHSVerb pos hsTyStr:CHSTokAmp _:toks'2) ->
           return (hsTyStr, True , pos, toks'2)
-        (CHSTokHSVerb pos hsTyStr            :toks'2) -> 
+        (CHSTokHSVerb pos hsTyStr            :toks'2) ->
           return (hsTyStr, False, pos, toks'2)
         toks                                          -> syntaxError toks
     (oomMarsh, toks'3) <- parseOptMarsh toks'2
     return (CHSParm oimMarsh hsTyStr twoCVals oomMarsh pos, toks'3)
   where
     parseOptMarsh :: [CHSToken] -> CST s (Maybe (Ident, CHSArg), [CHSToken])
-    parseOptMarsh (CHSTokIdent _ ide:CHSTokStar _ :toks) = 
+    parseOptMarsh (CHSTokIdent _ ide:CHSTokStar _ :toks) =
       return (Just (ide, CHSIOArg) , toks)
-    parseOptMarsh (CHSTokIdent _ ide:CHSTokMinus _:toks) = 
+    parseOptMarsh (CHSTokIdent _ ide:CHSTokMinus _:toks) =
       return (Just (ide, CHSVoidArg), toks)
-    parseOptMarsh (CHSTokIdent _ ide              :toks) = 
+    parseOptMarsh (CHSTokIdent _ ide              :toks) =
       return (Just (ide, CHSValArg) , toks)
     parseOptMarsh toks                                   =
       return (Nothing, toks)
@@ -977,14 +977,14 @@ parseField pos access toks =
 parsePointer :: Position -> [CHSToken] -> CST s [CHSFrag]
 parsePointer pos toks =
   do
-    (isStar, ide, toks')          <- 
+    (isStar, ide, toks')          <-
       case toks of
         CHSTokStar _:CHSTokIdent _ ide:toks' -> return (True , ide, toks')
         CHSTokIdent _ ide             :toks' -> return (False, ide, toks')
         _                                    -> syntaxError toks
     (oalias , toks'2)             <- parseOptAs ide True toks'
     (ptrType, toks'3)             <- parsePtrType        toks'2
-    let 
+    let
      (isNewtype, oRefType, toks'4) =
       case toks'3 of
         CHSTokNewtype _                  :toks' -> (True , Nothing , toks' )
@@ -992,8 +992,8 @@ parsePointer pos toks =
         _                                       -> (False, Nothing , toks'3)
     toks'5                        <- parseEndHook toks'4
     frags                         <- parseFrags   toks'5
-    return $ 
-      CHSHook 
+    return $
+      CHSHook
        (CHSPointer isStar ide (norm ide oalias) ptrType isNewtype oRefType pos)
        : frags
   where
@@ -1071,29 +1071,29 @@ parseOptPrefix _     toks                  = return (Nothing, toks)
 -- the second indicates whether the first character has to be upper case
 --
 parseOptAs :: Ident -> Bool -> [CHSToken] -> CST s (Maybe Ident, [CHSToken])
-parseOptAs _   _     (CHSTokAs _:CHSTokIdent _ ide:toks) = 
+parseOptAs _   _     (CHSTokAs _:CHSTokIdent _ ide:toks) =
   return (Just ide, toks)
-parseOptAs ide upper (CHSTokAs _:CHSTokHat pos    :toks) = 
+parseOptAs ide upper (CHSTokAs _:CHSTokHat pos    :toks) =
   return (Just $ underscoreToCase ide upper pos, toks)
 parseOptAs _   _     (CHSTokAs _                  :toks) = syntaxError toks
-parseOptAs _   _                                   toks  = 
+parseOptAs _   _                                   toks  =
   return (Nothing, toks)
 
 -- convert C style identifier to Haskell style identifier
 --
 underscoreToCase               :: Ident -> Bool -> Position -> Ident
-underscoreToCase ide upper pos  = 
+underscoreToCase ide upper pos  =
   let lexeme = identToLexeme ide
       ps     = filter (not . null) . parts $ lexeme
   in
   onlyPosIdent pos . adjustHead . concat . map adjustCase $ ps
   where
     parts s = let (l, s') = break (== '_') s
-              in  
+              in
               l : case s' of
                     []      -> []
                     (_:s'') -> parts s''
-    --    
+    --
     adjustCase (c:cs) = toUpper c : map toLower cs
     --
     adjustHead ""     = ""
@@ -1119,13 +1119,13 @@ parsePath' (CHSTokDot _:CHSTokIdent _ ide:toks) =
   do
     (pathWithHole, toks') <- parsePath' toks
     return (pathWithHole . (\hole -> CHSRef hole ide), toks')
-parsePath' (CHSTokDot _:toks) = 
+parsePath' (CHSTokDot _:toks) =
   syntaxError toks
 parsePath' (CHSTokArrow pos:CHSTokIdent _ ide:toks) =
   do
     (pathWithHole, toks') <- parsePath' toks
     return (pathWithHole . (\hole -> CHSRef (CHSDeref hole pos) ide), toks')
-parsePath' (CHSTokArrow _:toks) = 
+parsePath' (CHSTokArrow _:toks) =
   syntaxError toks
 parsePath' toks =
   do
@@ -1143,7 +1143,7 @@ parseTrans (CHSTokLBrace _:toks) =
           -- if there was no `underscoreToCase', we add a comma token to meet
           -- the invariant of `parseTranss'
           --
-          (transs, toks'') <- if _2Case 
+          (transs, toks'') <- if _2Case
                               then parseTranss toks'
                               else parseTranss (CHSTokComma nopos:toks')
           return (CHSTrans _2Case transs, toks'')
@@ -1169,9 +1169,9 @@ parseTrans (CHSTokLBrace _:toks) =
 parseTrans toks = syntaxError toks
 
 parseDerive :: [CHSToken] -> CST s ([Ident], [CHSToken])
-parseDerive (CHSTokDerive _ :CHSTokLParen _:CHSTokRParen _:toks) = 
+parseDerive (CHSTokDerive _ :CHSTokLParen _:CHSTokRParen _:toks) =
   return ([], toks)
-parseDerive (CHSTokDerive _ :CHSTokLParen _:toks)                = 
+parseDerive (CHSTokDerive _ :CHSTokLParen _:toks)                =
   parseCommaIdent (CHSTokComma nopos:toks)
   where
     parseCommaIdent :: [CHSToken] -> CST s ([Ident], [CHSToken])
@@ -1179,7 +1179,7 @@ parseDerive (CHSTokDerive _ :CHSTokLParen _:toks)                =
       do
         (ids, tok') <- parseCommaIdent toks
         return (ide:ids, tok')
-    parseCommaIdent (CHSTokRParen _                 :toks) = 
+    parseCommaIdent (CHSTokRParen _                 :toks) =
       return ([], toks)
 parseDerive toks = return ([],toks)
 
@@ -1205,29 +1205,29 @@ errorIllegal tok  = do
 
 errorEOF :: CST s a
 errorEOF  = do
-              raiseError nopos 
+              raiseError nopos
                 ["Premature end of file!",
                  "The .chs file ends in the middle of a binding hook."]
               raiseSyntaxError
 
 errorCHINotFound     :: String -> CST s a
 errorCHINotFound ide  = do
-  raiseError nopos 
+  raiseError nopos
     ["Unknown .chi file!",
      "Cannot find the .chi file for `" ++ ide ++ "'."]
   raiseSyntaxError
 
 errorCHICorrupt      :: String -> CST s a
 errorCHICorrupt ide  = do
-  raiseError nopos 
+  raiseError nopos
     ["Corrupt .chi file!",
      "The file `" ++  ide ++ ".chi' is corrupt."]
   raiseSyntaxError
 
 errorCHIVersion :: String -> String -> String -> CST s a
 errorCHIVersion ide chiVersion myVersion  = do
-  raiseError nopos 
+  raiseError nopos
     ["Wrong version of .chi file!",
-     "The file `" ++ ide ++ ".chi' is version " 
+     "The file `" ++ ide ++ ".chi' is version "
      ++ chiVersion ++ ", but mine is " ++ myVersion ++ "."]
   raiseSyntaxError

--- a/tools/c2hs/chs/CHSLexer.hs
+++ b/tools/c2hs/chs/CHSLexer.hs
@@ -28,7 +28,7 @@
 --  * CHS files are assumed to be Haskell 98 files that include C2HS binding
 --    hooks.
 --
---  * Haskell code is not tokenised, but binding hooks (delimited by `{#'and 
+--  * Haskell code is not tokenised, but binding hooks (delimited by `{#'and
 --    `#}') are analysed.  Therefore the lexer operates in two states
 --    (realised as two lexer coupled by meta actions) depending on whether
 --    Haskell code or a binding hook is currently read.  The lexer reading
@@ -90,12 +90,12 @@
 --
 --      ident       -> letter (letter | digit | `\'')*
 --                   | `\'' letter (letter | digit)* `\''
---      reservedid  -> `as' | `call' | `class' | `context' | `deriving' 
---                   | `enum' | `foreign' | `fun' | `get' | `lib' 
+--      reservedid  -> `as' | `call' | `class' | `context' | `deriving'
+--                   | `enum' | `foreign' | `fun' | `get' | `lib'
 --                   | `newtype' | `pointer' | `prefix' | `pure' | `set'
---                   | `sizeof' | `stable' | `type' | `underscoreToCase' 
+--                   | `sizeof' | `stable' | `type' | `underscoreToCase'
 --                   | `unsafe' | `with' | 'lock' | 'unlock'
---      reservedsym -> `{#' | `#}' | `{' | `}' | `,' | `.' | `->' | `=' 
+--      reservedsym -> `{#' | `#}' | `{' | `}' | `,' | `.' | `->' | `='
 --                   | `=>' | '-' | `*' | `&' | `^'
 --      string      -> `"' instr* `"'
 --      verbhs      -> `\`' instr* `\''
@@ -107,14 +107,14 @@
 --    Identifiers can be enclosed in single quotes to avoid collision with
 --    C->Haskell keywords.
 --
---  * In the binding-hook lexer, the lexeme `#}' transfers control back to the 
+--  * In the binding-hook lexer, the lexeme `#}' transfers control back to the
 --    base lexer.  An occurrence of the lexeme `{#' inside the binding-hook
 --    lexer triggers an error.  The symbol `{#' is not explicitly represented
 --    in the resulting token stream.  However, the occurrence of a token
 --    representing one of the reserved identifiers `call', `context', `enum',
 --    and `field' marks the start of a binding hook.  Strictly speaking, `#}'
 --    need also not occur in the token stream, as the next `haskell' token
---    marks a hook's end.  It is, however, useful for producing accurate error 
+--    marks a hook's end.  It is, however, useful for producing accurate error
 --    messages (in case an hook is closed to early) to have a token
 --    representing `#}'.
 --
@@ -160,14 +160,14 @@
 --
 --  * In `haskell', the case of a single `"' (without a matching second one)
 --    is caught by an eplicit error raising rule.  This shouldn't be
---    necessary, but for some strange reason, the lexer otherwise hangs when a 
+--    necessary, but for some strange reason, the lexer otherwise hangs when a
 --    single `"' appears in the input.
 --
 --  * Comments in the "gap" of a string are not yet supported.
 --
 
-module CHSLexer (CHSToken(..), lexCHS) 
-where 
+module CHSLexer (CHSToken(..), lexCHS)
+where
 
 import Data.List         ((\\))
 import Data.Char         (isDigit)
@@ -182,7 +182,7 @@ import Lexers    (Regexp, Lexer, Action, epsilon, char, (+>), lexaction,
                   lexactionErr, lexmeta, (>|<), (>||<), ctrlLexer, star, plus,
                   quest, alt, string, LexerState, execLexer)
 
-import C2HSState (CST, raise, raiseError, nop, getNameSupply) 
+import C2HSState (CST, raise, raiseError, nop, getNameSupply)
 
 
 -- token definition
@@ -229,7 +229,7 @@ data CHSToken = CHSTokArrow   Position          -- `->'
               | CHSTokWith    Position          -- `with'
               | CHSTokLock    Position          -- `lock'
               | CHSTokNolock  Position          -- `nolock'
-              | CHSTokString  Position String   -- string 
+              | CHSTokString  Position String   -- string
               | CHSTokHSVerb  Position String   -- verbatim Haskell (`...')
               | CHSTokIdent   Position Ident    -- identifier
               | CHSTokHaskell Position String   -- verbatim Haskell code
@@ -417,7 +417,7 @@ initialState  = do
 -- raise an error if the given state is not a final state
 --
 assertFinalState :: Position -> CHSLexerState -> CST s ()
-assertFinalState pos CHSLS {nestLvl = nestLvl, inHook = inHook} 
+assertFinalState pos CHSLS {nestLvl = nestLvl, inHook = inHook}
   | nestLvl > 0 = raiseError pos ["Unexpected end of file!",
                                   "Unclosed nested comment."]
   | inHook      = raiseError pos ["Unexpected end of file!",
@@ -433,8 +433,8 @@ type CHSRegexp = Regexp CHSLexerState CHSToken
 -- for actions that need a new unique name
 --
 infixl 3 `lexactionName`
-lexactionName :: CHSRegexp 
-              -> (String -> Position -> Name -> CHSToken) 
+lexactionName :: CHSRegexp
+              -> (String -> Position -> Name -> CHSToken)
               -> CHSLexer
 re `lexactionName` action = re `lexmeta` action'
   where
@@ -492,9 +492,9 @@ haskell  = (    anyButSpecial`star` epsilon
            )
            `lexaction` copyVerbatim
            >||< char '"'                                -- this is a bad kludge
-                `lexactionErr` 
+                `lexactionErr`
                   \_ pos -> (Left $ makeError ErrorErr pos
-                                              ["Lexical error!", 
+                                              ["Lexical error!",
                                               "Unclosed string."])
            where
              anyButSpecial    = alt (inlineSet \\ specialSet)
@@ -505,7 +505,7 @@ haskell  = (    anyButSpecial`star` epsilon
 
 -- action copying the input verbatim to `CHSTokHaskell' tokens
 --
-copyVerbatim        :: CHSAction 
+copyVerbatim        :: CHSAction
 copyVerbatim cs pos  = Just $ CHSTokHaskell pos cs
 
 -- nested comments
@@ -543,7 +543,7 @@ nested  =
     --
     commentCloseErr pos =
       Just $ Left (makeError ErrorErr pos
-                             ["Lexical error!", 
+                             ["Lexical error!",
                              "`-}' not preceded by a matching `{-'."])
                              {- for Haskell emacs mode :-( -}
 
@@ -572,7 +572,7 @@ commentInterior  = (    anyButSpecial`star` epsilon
 --   and `Lexers.ctrlLexer' and advances positions also like the `ctrlLexer'
 --
 ctrl :: CHSLexer
-ctrl  =     
+ctrl  =
        char '\n' `lexmeta` newline
   >||< char '\r' `lexmeta` newline
   >||< char '\v' `lexmeta` newline
@@ -583,7 +583,7 @@ ctrl  =
     formfeed [c] pos = ctrlResult pos c (incPos pos 1)
     tab      [c] pos = ctrlResult pos c (tabPos pos)
 
-    ctrlResult pos c pos' s = 
+    ctrlResult pos c pos' s =
       (Just $ Right (CHSTokCtrl pos c), pos', s, Nothing)
 
 -- start of a binding hook (ie, enter the binding hook lexer)
@@ -601,9 +601,9 @@ hook  = string "{#"
 cpp :: CHSLexer
 cpp = directive
       where
-        directive = 
+        directive =
           string "\n#" +> alt ('\t':inlineSet)`star` epsilon
-          `lexmeta` 
+          `lexmeta`
              \(_:_:dir) pos s ->        -- strip off the "\n#"
                case dir of
                  ['c']                      ->          -- #c
@@ -615,11 +615,11 @@ cpp = directive
                    let pos' = adjustPosByCLinePragma line pos
                     in (Just $ Right (CHSTokLine pos'), pos', s, Nothing)
                  _                            ->        -- CPP directive
-                   (Just $ Right (CHSTokCPP pos dir), 
+                   (Just $ Right (CHSTokCPP pos dir),
                     retPos pos, s, Nothing)
 
 adjustPosByCLinePragma :: String -> Position -> Position
-adjustPosByCLinePragma str (Position fname _ _) = 
+adjustPosByCLinePragma str (Position fname _ _) =
   (Position fname' row' 0)
   where
     str'            = dropWhite str
@@ -648,8 +648,8 @@ bhLexer  =      identOrKW
            where
              anyButNL  = alt (anySet \\ ['\n'])
              endOfHook = string "#}"
-                         `lexmeta` 
-                          \_ pos s -> (Just $ Right (CHSTokEndHook pos), 
+                         `lexmeta`
+                          \_ pos s -> (Just $ Right (CHSTokEndHook pos),
                                        incPos pos 2, s, Just chslexer)
 
 -- the inline-C lexer
@@ -659,18 +659,18 @@ cLexer =      inlineC                     -- inline C code
          >||< ctrl                        -- control code (preserved)
          >||< string "\n#endc"            -- end of inline C code...
               `lexmeta`                   -- ...preserve '\n' as control token
-              \_ pos s -> (Just $ Right (CHSTokCtrl pos '\n'), retPos pos, s, 
+              \_ pos s -> (Just $ Right (CHSTokCtrl pos '\n'), retPos pos, s,
                            Just chslexer)
          where
            inlineC = alt inlineSet `lexaction` copyVerbatimC
            --
-           copyVerbatimC :: CHSAction 
+           copyVerbatimC :: CHSAction
            copyVerbatimC cs pos = Just $ CHSTokC pos cs
 
 -- whitespace
 --
 --  * horizontal and vertical tabs, newlines, and form feeds are filter out by
---   `Lexers.ctrlLexer' 
+--   `Lexers.ctrlLexer'
 --
 whitespace :: CHSLexer
 whitespace  =      (char ' ' `lexaction` \_ _ -> Nothing)
@@ -682,7 +682,7 @@ identOrKW :: CHSLexer
 --
 -- the strictness annotations seem to help a bit
 --
-identOrKW  = 
+identOrKW  =
        -- identifier or keyword
        (letter +> (letter >|< digit >|< char '\'')`star` epsilon
        `lexactionName` \cs pos name -> (idkwtok $!pos) cs name)
@@ -775,14 +775,14 @@ ctrlSet           = ['\n', '\f', '\r', '\t', '\v']
 -- -------------------
 
 -- generate a token sequence out of a string denoting a CHS file
--- (EXPORTED) 
+-- (EXPORTED)
 --
 --  * the given position is attributed to the first character in the string
 --
 --  * errors are entered into the compiler state
 --
 lexCHS        :: String -> Position -> CST s [CHSToken]
-lexCHS cs pos  = 
+lexCHS cs pos  =
   do
     state <- initialState
     let (ts, lstate, errs) = execLexer chslexer (cs, pos, state)

--- a/tools/c2hs/config.guess
+++ b/tools/c2hs/config.guess
@@ -3,7 +3,7 @@
 #   Copyright (C) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999,
 #   2000, 2001, 2002 Free Software Foundation, Inc.
 
-timestamp='2002-03-20'
+timestamp='2025-05-17'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -845,7 +845,7 @@ EOF
 		;;
 	  a.out-i386-linux)
 		echo "${UNAME_MACHINE}-pc-linux-gnuaout"
-		exit 0 ;;		
+		exit 0 ;;
 	  coff-i386)
 		echo "${UNAME_MACHINE}-pc-linux-gnucoff"
 		exit 0 ;;
@@ -866,9 +866,9 @@ EOF
 	#  else
 	LIBC=gnulibc1
 	#  endif
-	# else
+	#else
 	LIBC=gnulibc1
-	# endif
+	#endif
 	#else
 	#ifdef __INTEL_COMPILER
 	LIBC=gnu
@@ -1228,9 +1228,9 @@ main ()
 #  else
     printf ("vax-dec-bsd\n"); exit (0);
 #  endif
-# else
+#else
     printf ("vax-dec-ultrix\n"); exit (0);
-# endif
+#endif
 #endif
 
 #if defined (alliant) && defined (i860)

--- a/tools/c2hs/doc/c2hs/lib/CError.hs
+++ b/tools/c2hs/doc/c2hs/lib/CError.hs
@@ -7,19 +7,19 @@ module CError (
   -- Haskell representation for "errno" values
   --
   Errno(..),            -- instance: Eq
-  eOK, e2BIG, eACCES, eADDRINUSE, eADDRNOTAVAIL, eADV, eAFNOSUPPORT, eAGAIN, 
-  eALREADY, eBADF, eBADMSG, eBADRPC, eBUSY, eCHILD, eCOMM, eCONNABORTED, 
-  eCONNREFUSED, eCONNRESET, eDEADLK, eDESTADDRREQ, eDIRTY, eDOM, eDQUOT, 
-  eEXIST, eFAULT, eFBIG, eFTYPE, eHOSTDOWN, eHOSTUNREACH, eIDRM, eILSEQ, 
-  eINPROGRESS, eINTR, eINVAL, eIO, eISCONN, eISDIR, eLOOP, eMFILE, eMLINK, 
-  eMSGSIZE, eMULTIHOP, eNAMETOOLONG, eNETDOWN, eNETRESET, eNETUNREACH, 
-  eNFILE, eNOBUFS, eNODATA, eNODEV, eNOENT, eNOEXEC, eNOLCK, eNOLINK, 
-  eNOMEM, eNOMSG, eNONET, eNOPROTOOPT, eNOSPC, eNOSR, eNOSTR, eNOSYS, 
-  eNOTBLK, eNOTCONN, eNOTDIR, eNOTEMPTY, eNOTSOCK, eNOTTY, eNXIO, 
-  eOPNOTSUPP, ePERM, ePFNOSUPPORT, ePIPE, ePROCLIM, ePROCUNAVAIL, 
-  ePROGMISMATCH, ePROGUNAVAIL, ePROTO, ePROTONOSUPPORT, ePROTOTYPE, 
-  eRANGE, eREMCHG, eREMOTE, eROFS, eRPCMISMATCH, eRREMOTE, eSHUTDOWN, 
-  eSOCKTNOSUPPORT, eSPIPE, eSRCH, eSRMNT, eSTALE, eTIME, eTIMEDOUT, 
+  eOK, e2BIG, eACCES, eADDRINUSE, eADDRNOTAVAIL, eADV, eAFNOSUPPORT, eAGAIN,
+  eALREADY, eBADF, eBADMSG, eBADRPC, eBUSY, eCHILD, eCOMM, eCONNABORTED,
+  eCONNREFUSED, eCONNRESET, eDEADLK, eDESTADDRREQ, eDIRTY, eDOM, eDQUOT,
+  eEXIST, eFAULT, eFBIG, eFTYPE, eHOSTDOWN, eHOSTUNREACH, eIDRM, eILSEQ,
+  eINPROGRESS, eINTR, eINVAL, eIO, eISCONN, eISDIR, eLOOP, eMFILE, eMLINK,
+  eMSGSIZE, eMULTIHOP, eNAMETOOLONG, eNETDOWN, eNETRESET, eNETUNREACH,
+  eNFILE, eNOBUFS, eNODATA, eNODEV, eNOENT, eNOEXEC, eNOLCK, eNOLINK,
+  eNOMEM, eNOMSG, eNONET, eNOPROTOOPT, eNOSPC, eNOSR, eNOSTR, eNOSYS,
+  eNOTBLK, eNOTCONN, eNOTDIR, eNOTEMPTY, eNOTSOCK, eNOTTY, eNXIO,
+  eOPNOTSUPP, ePERM, ePFNOSUPPORT, ePIPE, ePROCLIM, ePROCUNAVAIL,
+  ePROGMISMATCH, ePROGUNAVAIL, ePROTO, ePROTONOSUPPORT, ePROTOTYPE,
+  eRANGE, eREMCHG, eREMOTE, eROFS, eRPCMISMATCH, eRREMOTE, eSHUTDOWN,
+  eSOCKTNOSUPPORT, eSPIPE, eSRCH, eSRMNT, eSTALE, eTIME, eTIMEDOUT,
   eTOOMANYREFS, eTXTBSY, eUSERS, eWOULDBLOCK, eXDEV,
                         -- :: Errno
   isValidErrno,         -- :: Errno -> Bool
@@ -47,15 +47,15 @@ module CError (
   throwErrnoIf_,        -- :: (a -> Bool) -> String -> IO a       -> IO ()
   throwErrnoIfRetry,    -- :: (a -> Bool) -> String -> IO a       -> IO a
   throwErrnoIfRetry_,   -- :: (a -> Bool) -> String -> IO a       -> IO ()
-  throwErrnoIfMinus1,   -- :: Num a 
+  throwErrnoIfMinus1,   -- :: Num a
                         -- =>                String -> IO a       -> IO a
-  throwErrnoIfMinus1_,  -- :: Num a 
+  throwErrnoIfMinus1_,  -- :: Num a
                         -- =>                String -> IO a       -> IO ()
-  throwErrnoIfMinus1Retry,  
-                        -- :: Num a 
+  throwErrnoIfMinus1Retry,
+                        -- :: Num a
                         -- =>                String -> IO a       -> IO a
-  throwErrnoIfMinus1Retry_,  
-                        -- :: Num a 
+  throwErrnoIfMinus1Retry_,
+                        -- :: Num a
                         -- =>                String -> IO a       -> IO ()
   throwErrnoIfNull,     -- ::                String -> IO (Ptr a) -> IO (Ptr a)
   throwErrnoIfNullRetry -- ::                String -> IO (Ptr a) -> IO (Ptr a)
@@ -87,25 +87,25 @@ foreign label "errno" _errno :: Ptr CInt
 newtype Errno = Errno CInt
 
 instance Eq Errno where
-  errno1@(Errno no1) == errno2@(Errno no2) 
+  errno1@(Errno no1) == errno2@(Errno no2)
     | isValidErrno errno1 && isValidErrno errno2 = no1 == no2
     | otherwise                                  = False
 
 -- common "errno" symbols
 --
-eOK, e2BIG, eACCES, eADDRINUSE, eADDRNOTAVAIL, eADV, eAFNOSUPPORT, eAGAIN, 
-  eALREADY, eBADF, eBADMSG, eBADRPC, eBUSY, eCHILD, eCOMM, eCONNABORTED, 
-  eCONNREFUSED, eCONNRESET, eDEADLK, eDESTADDRREQ, eDIRTY, eDOM, eDQUOT, 
-  eEXIST, eFAULT, eFBIG, eFTYPE, eHOSTDOWN, eHOSTUNREACH, eIDRM, eILSEQ, 
-  eINPROGRESS, eINTR, eINVAL, eIO, eISCONN, eISDIR, eLOOP, eMFILE, eMLINK, 
-  eMSGSIZE, eMULTIHOP, eNAMETOOLONG, eNETDOWN, eNETRESET, eNETUNREACH, 
-  eNFILE, eNOBUFS, eNODATA, eNODEV, eNOENT, eNOEXEC, eNOLCK, eNOLINK, 
-  eNOMEM, eNOMSG, eNONET, eNOPROTOOPT, eNOSPC, eNOSR, eNOSTR, eNOSYS, 
-  eNOTBLK, eNOTCONN, eNOTDIR, eNOTEMPTY, eNOTSOCK, eNOTTY, eNXIO, 
-  eOPNOTSUPP, ePERM, ePFNOSUPPORT, ePIPE, ePROCLIM, ePROCUNAVAIL, 
-  ePROGMISMATCH, ePROGUNAVAIL, ePROTO, ePROTONOSUPPORT, ePROTOTYPE, 
-  eRANGE, eREMCHG, eREMOTE, eROFS, eRPCMISMATCH, eRREMOTE, eSHUTDOWN, 
-  eSOCKTNOSUPPORT, eSPIPE, eSRCH, eSRMNT, eSTALE, eTIME, eTIMEDOUT, 
+eOK, e2BIG, eACCES, eADDRINUSE, eADDRNOTAVAIL, eADV, eAFNOSUPPORT, eAGAIN,
+  eALREADY, eBADF, eBADMSG, eBADRPC, eBUSY, eCHILD, eCOMM, eCONNABORTED,
+  eCONNREFUSED, eCONNRESET, eDEADLK, eDESTADDRREQ, eDIRTY, eDOM, eDQUOT,
+  eEXIST, eFAULT, eFBIG, eFTYPE, eHOSTDOWN, eHOSTUNREACH, eIDRM, eILSEQ,
+  eINPROGRESS, eINTR, eINVAL, eIO, eISCONN, eISDIR, eLOOP, eMFILE, eMLINK,
+  eMSGSIZE, eMULTIHOP, eNAMETOOLONG, eNETDOWN, eNETRESET, eNETUNREACH,
+  eNFILE, eNOBUFS, eNODATA, eNODEV, eNOENT, eNOEXEC, eNOLCK, eNOLINK,
+  eNOMEM, eNOMSG, eNONET, eNOPROTOOPT, eNOSPC, eNOSR, eNOSTR, eNOSYS,
+  eNOTBLK, eNOTCONN, eNOTDIR, eNOTEMPTY, eNOTSOCK, eNOTTY, eNXIO,
+  eOPNOTSUPP, ePERM, ePFNOSUPPORT, ePIPE, ePROCLIM, ePROCUNAVAIL,
+  ePROGMISMATCH, ePROGUNAVAIL, ePROTO, ePROTONOSUPPORT, ePROTOTYPE,
+  eRANGE, eREMCHG, eREMOTE, eROFS, eRPCMISMATCH, eRREMOTE, eSHUTDOWN,
+  eSOCKTNOSUPPORT, eSPIPE, eSRCH, eSRMNT, eSTALE, eTIME, eTIMEDOUT,
   eTOOMANYREFS, eTXTBSY, eUSERS, eWOULDBLOCK, eXDEV                    :: Errno
 --
 -- the @CCONST_XXX@ identifiers have to replaced by the appropriate
@@ -256,7 +256,7 @@ throwErrno loc  =
 -- value of the IO operation meets the given predicate
 --
 throwErrnoIf            :: (a -> Bool) -> String -> IO a -> IO a
-throwErrnoIf pred loc f  = 
+throwErrnoIf pred loc f  =
   do
     res <- f
     if pred res then throwErrno loc else return res
@@ -270,7 +270,7 @@ throwErrnoIf_ pred loc f  = void $ throwErrnoIf pred loc f
 -- flag `EINTR')
 --
 throwErrnoIfRetry            :: (a -> Bool) -> String -> IO a -> IO a
-throwErrnoIfRetry pred loc f  = 
+throwErrnoIfRetry pred loc f  =
   do
     res <- f
     if pred res

--- a/tools/c2hs/doc/c2hs/lib/CForeign.hs
+++ b/tools/c2hs/doc/c2hs/lib/CForeign.hs
@@ -2,7 +2,7 @@
 --
 -- Bundles the C specific FFI library functionality
 
-module CForeign ( 
+module CForeign (
   module CTypes,
   module CTypesISO,
   module CError,

--- a/tools/c2hs/doc/c2hs/lib/CString.hs
+++ b/tools/c2hs/doc/c2hs/lib/CString.hs
@@ -68,12 +68,12 @@ type CStringLen = (CString, Int)        -- strings with explicit length
 --   middle of a string
 --
 
--- marshal a NUL terminated C string into a Haskell string 
+-- marshal a NUL terminated C string into a Haskell string
 --
 peekCString    :: CString -> IO String
 peekCString cp  = liftM cCharsToChars $ peekArray0 nUL cp
 
--- marshal a C string with explicit length into a Haskell string 
+-- marshal a C string with explicit length into a Haskell string
 --
 peekCStringLen           :: CStringLen -> IO String
 peekCStringLen (cp, len)  = liftM cCharsToChars $ peekArray len cp

--- a/tools/c2hs/doc/c2hs/lib/Foreign.hs
+++ b/tools/c2hs/doc/c2hs/lib/Foreign.hs
@@ -2,7 +2,7 @@
 --
 -- Bundles the language-independent FFI library functionality
 
-module Foreign ( 
+module Foreign (
   module Int,
   module Word,
   module Ptr,

--- a/tools/c2hs/doc/c2hs/lib/ForeignPtr.hs
+++ b/tools/c2hs/doc/c2hs/lib/ForeignPtr.hs
@@ -27,7 +27,7 @@ newtype ForeignPtr a = ForeignPtr (Ptr a)
 --
 --  * There is no guarantee on how soon the finaliser is executed after the
 --   last reference was dropped; this depends on the details of the Haskell
---   storage manager 
+--   storage manager
 --
 --  * The only guarantee given is that the finaliser runs before the program
 --   terminates
@@ -63,7 +63,7 @@ touchForeignPtr (ForeignPtr fo)  =
   fo `seq` return ()
 
 -- Applies an operation to the vanilla pointer associated with a foreign
--- pointer 
+-- pointer
 --
 --  * The foreign object is kept alive at least during the whole action, even
 --   if it is not used directly inside. Note that it is not safe to return the
@@ -83,7 +83,7 @@ withForeignPtr (ForeignPtr fp) m  = do
 --   then its finaliser(s) will be run, which potentially invalidates the
 --   plain pointer just obtained. Hence, `touchForeignPtr' must be used
 --   wherever it has to be guaranteed that the pointer lives on - i.e., has
---   another usage occurrence. 
+--   another usage occurrence.
 --
 --  * To avoid subtle coding errors, hand written marshalling code should
 --   preferably use `withForeignPtr' rather than combinations of

--- a/tools/c2hs/doc/c2hs/lib/MarshalAlloc.hs
+++ b/tools/c2hs/doc/c2hs/lib/MarshalAlloc.hs
@@ -61,7 +61,7 @@ allocaBytes size  = bracket (mallocBytes size) free
 -- adjust a malloc'ed storage area to the given size
 --
 reallocBytes          :: Ptr a -> Int -> IO (Ptr a)
-reallocBytes ptr size  = 
+reallocBytes ptr size  =
   failWhenNULL "realloc" (_realloc ptr (fromIntegral size))
 
 -- free malloc'ed storage

--- a/tools/c2hs/doc/c2hs/lib/MarshalError.hs
+++ b/tools/c2hs/doc/c2hs/lib/MarshalError.hs
@@ -8,7 +8,7 @@ module MarshalError (
   --
   throwIf,       -- :: (a -> Bool) -> (a -> String) -> IO a       -> IO a
   throwIf_,      -- :: (a -> Bool) -> (a -> String) -> IO a       -> IO ()
-  throwIfNeg,    -- :: (Ord a, Num a) 
+  throwIfNeg,    -- :: (Ord a, Num a)
                  -- =>                (a -> String) -> IO a       -> IO a
   throwIfNeg_,   -- :: (Ord a, Num a)
                  -- =>                (a -> String) -> IO a       -> IO ()
@@ -23,13 +23,13 @@ import Ptr (Ptr, nullPtr)
 
 
 -- guard an IO operation and throw an exception if the result meets the given
--- predicate 
+-- predicate
 --
 --  * the second argument computes an error message from the result of the IO
 --   operation
 --
 throwIf                 :: (a -> Bool) -> (a -> String) -> IO a -> IO a
-throwIf pred msgfct act  = 
+throwIf pred msgfct act  =
   do
     res <- act
     (if pred res then ioError . userError . msgfct else return) res

--- a/tools/c2hs/doc/c2hs/lib/MarshalUtils.hs
+++ b/tools/c2hs/doc/c2hs/lib/MarshalUtils.hs
@@ -18,9 +18,9 @@ module MarshalUtils (
   --
   maybeNew,      -- :: (      a -> IO (Ptr a))
                  -- -> (Maybe a -> IO (Ptr a))
-  maybeWith,     -- :: (      a -> (Ptr b -> IO c) -> IO c) 
+  maybeWith,     -- :: (      a -> (Ptr b -> IO c) -> IO c)
                  -- -> (Maybe a -> (Ptr b -> IO c) -> IO c)
-  maybePeek,     -- :: (Ptr a -> IO        b ) 
+  maybePeek,     -- :: (Ptr a -> IO        b )
                  -- -> (Ptr a -> IO (Maybe b))
 
   -- marshalling lists of storable objects
@@ -48,8 +48,8 @@ import MarshalAlloc (malloc, alloca)
 -- allocate storage for a value and marshal it into this storage
 --
 new     :: Storable a => a -> IO (Ptr a)
-new val  = 
-  do 
+new val  =
+  do
     ptr <- malloc
     poke ptr val
     return ptr
@@ -91,12 +91,12 @@ maybeNew  = maybe (return nullPtr)
 -- converts a withXXX combinator into one marshalling a value wrapped into a
 -- `Maybe'
 --
-maybeWith :: (      a -> (Ptr b -> IO c) -> IO c) 
+maybeWith :: (      a -> (Ptr b -> IO c) -> IO c)
           -> (Maybe a -> (Ptr b -> IO c) -> IO c)
 maybeWith  = maybe ($ nullPtr)
 
 -- convert a peek combinator into a one returning `Nothing' if applied to a
--- `nullPtr' 
+-- `nullPtr'
 --
 maybePeek                           :: (Ptr a -> IO b) -> Ptr a -> IO (Maybe b)
 maybePeek peek ptr | ptr == nullPtr  = return Nothing

--- a/tools/c2hs/doc/c2hs/lib/StablePtr.hs
+++ b/tools/c2hs/doc/c2hs/lib/StablePtr.hs
@@ -5,7 +5,7 @@
 -- will the value of the stable pointer itself change during garbage
 -- collection (ordinary references may be relocated during garbage
 -- collection). Consequently, stable pointers can be passed to foreign code,
--- which can handle it as an opaque reference to a Haskell value. 
+-- which can handle it as an opaque reference to a Haskell value.
 
 module StablePtr (
   StablePtr,          -- data StablePtr a; instances: Eq
@@ -50,7 +50,7 @@ deRefStablePtr (StablePtr sp)  = do
 --   may still be passed to `castStablePtrToPtr', but the `Ptr ()' value
 --   returned by `castStablePtrToPtr', in this case, is undefined (in
 --   particular, it may be `Ptr.nullPtr'). Nevertheless, the call is guaranteed
---   not to diverge. 
+--   not to diverge.
 --
 freeStablePtr                :: StablePtr a -> IO ()
 freeStablePtr (StablePtr sp)  = do

--- a/tools/c2hs/doc/c2hs/lib/Storable.hs
+++ b/tools/c2hs/doc/c2hs/lib/Storable.hs
@@ -32,7 +32,7 @@ class Storable a where
    -- Yields the alignment constraint of the argument
    --
    --  * An alignment constraint "x" is fulfilled by any address divisible by
-   --   "x" 
+   --   "x"
    --
    --  * Never uses its argument
    --

--- a/tools/c2hs/gen/CInfo.hs
+++ b/tools/c2hs/gen/CInfo.hs
@@ -55,19 +55,19 @@
 --
 
 module CInfo (
-  CPrimType(..), size, alignment, 
+  CPrimType(..), size, alignment,
   bitfieldDirection, bitfieldPadding, bitfieldIntSigned, bitfieldAlignment
-) where 
+) where
 
 import Foreign.C
 
 -- we can't rely on the compiler used to compile c2hs already having the new
 -- FFI, so this is system dependent
 --
-import C2HSConfig (Ptr, FunPtr, 
+import C2HSConfig (Ptr, FunPtr,
                    bitfieldDirection, bitfieldPadding, bitfieldIntSigned,
                    bitfieldAlignment)
-import qualified  
+import qualified
        C2HSConfig as Storable
                   (Storable(sizeOf, alignment))
 

--- a/tools/c2hs/gen/GBMonad.hs
+++ b/tools/c2hs/gen/GBMonad.hs
@@ -35,7 +35,7 @@
 --  is performed.  If this also doesn't match, the identifier without prefix
 --  (possible after underscoreToCase translation is returned).  If there is a
 --  match, the translation (without any further stripping of prefix) is
---  returned.  
+--  returned.
 --
 --  Pointer map
 --  -----------
@@ -108,11 +108,11 @@ underscoreToCase ide  = let lexeme = identToLexeme ide
                         concat . map adjustCase $ ps
                         where
                           parts s = let (l, s') = break (== '_') s
-                                    in  
+                                    in
                                     l : case s' of
                                           []      -> []
                                           (_:s'') -> parts s''
-                          
+
                           adjustCase (c:cs) = toUpper c : map toLower cs
 
 -- takes an identifier association table to a translation function
@@ -125,7 +125,7 @@ underscoreToCase ide  = let lexeme = identToLexeme ide
 --
 transTabToTransFun :: String -> CHSTrans -> TransFun
 transTabToTransFun prefix (CHSTrans _2Case table) =
-  \ide -> let 
+  \ide -> let
             lexeme = identToLexeme ide
             dft    = if _2Case                  -- default uses maybe the...
                      then underscoreToCase ide  -- ..._2case transformed...
@@ -133,14 +133,14 @@ transTabToTransFun prefix (CHSTrans _2Case table) =
           in
           case lookup ide table of                  -- lookup original ident
             Just ide' -> identToLexeme ide'         -- original ident matches
-            Nothing   -> 
+            Nothing   ->
               case eat prefix lexeme of
                 Nothing          -> dft             -- no match & no prefix
-                Just eatenLexeme -> 
-                  let 
+                Just eatenLexeme ->
+                  let
                     eatenIde = onlyPosIdent (posOf ide) eatenLexeme
-                    eatenDft = if _2Case 
-                               then underscoreToCase eatenIde 
+                    eatenDft = if _2Case
+                               then underscoreToCase eatenIde
                                else eatenLexeme
                   in
                   case lookup eatenIde table of     -- lookup without prefix
@@ -176,7 +176,7 @@ type PointerMap = Map (Bool, Ident) HsPtrRep
 --  * The first element is true if the pointer points to a function.
 --   The second is the Haskell pointer type (plain
 --   Ptr, ForeignPtr or StablePtr). The third field is (Just wrap) if the
---   pointer is wrapped in a newtype. Where "wrap" 
+--   pointer is wrapped in a newtype. Where "wrap"
 --   contains the name of the Haskell data type that was defined for this
 --   pointer. The forth element contains the type argument of the
 --   Ptr, ForeignPtr or StablePtr and is the same as "wrap"
@@ -203,16 +203,16 @@ type HsObjectMap = Map Ident HsObject
 
 {- FIXME: What a mess...
 instance Show HsObject where
-  show (Pointer ptrType isNewtype) = 
+  show (Pointer ptrType isNewtype) =
     "Pointer " ++ show ptrType ++ show isNewtype
-  show (Class   osuper  pointer  ) = 
+  show (Class   osuper  pointer  ) =
     "Class " ++ show ptrType ++ show isNewtype
 -}
 -- super kludgy (depends on Show instance of Ident)
 instance Read Ident where
   readsPrec _ ('`':lexeme) = let (ideChars, rest) = span (/= '\'') lexeme
                              in
-                             if null ideChars 
+                             if null ideChars
                              then []
                              else [(onlyPosIdent nopos ideChars, tail rest)]
   readsPrec p (c:cs)
@@ -230,7 +230,7 @@ instance Read Ident where
 --     that created them (the latter allows avoid duplication of foreign
 --     export declarations), and
 -- (4) a map associating C pointer types with their Haskell representation
---     
+--
 -- access to the attributes of the C structure tree is via the `CT' monad of
 -- which we use an instance here
 --
@@ -259,7 +259,7 @@ initialGBState mLock = GBState {
 --
 setContext            :: (Maybe String) -> (Maybe String) -> (Maybe String) ->
                          GB ()
-setContext lib prefix newMLock = 
+setContext lib prefix newMLock =
   transCT $ \state -> (state {lib    = fromMaybe "" lib,
                               prefix = fromMaybe "" prefix,
                               mLock  = case newMLock of
@@ -290,7 +290,7 @@ getLock = readCT mLock
 --   specify the same flags (ie, produce the same delayed code)
 --
 delayCode          :: CHSHook -> String -> GB ()
-delayCode hook str  = 
+delayCode hook str  =
   do
     frags <- readCT frags
     frags' <- delay hook frags
@@ -300,8 +300,8 @@ delayCode hook str  =
       --
       delay hook@(CHSCall isFun isUns _ ide oalias _) frags =
         case find (\(hook', _) -> hook' == hook) frags of
-          Just (CHSCall isFun' isUns' _ ide' _ _, _) 
-            |    isFun == isFun' 
+          Just (CHSCall isFun' isUns' _ ide' _ _, _)
+            |    isFun == isFun'
               && isUns == isUns'
               && ide   == ide'   -> return frags
             | otherwise          -> err (posOf ide) (posOf ide')
@@ -320,7 +320,7 @@ getDelayedCode  = readCT (map snd . frags)
 --
 ptrMapsTo :: (Bool, Ident) -> HsPtrRep -> GB ()
 (isStar, cName) `ptrMapsTo` hsRepr =
-  transCT (\state -> (state { 
+  transCT (\state -> (state {
                         ptrmap = Map.insert (isStar, cName) hsRepr (ptrmap state)
                       }, ()))
 
@@ -335,7 +335,7 @@ queryPtr pcName  = do
 --
 objIs :: Ident -> HsObject -> GB ()
 hsName `objIs` obj =
-  transCT (\state -> (state { 
+  transCT (\state -> (state {
                         objmap = Map.insert hsName obj (objmap state)
                       }, ()))
 
@@ -388,7 +388,7 @@ queryPointer hsName  = do
 --
 mergeMaps     :: String -> GB ()
 mergeMaps str  =
-  transCT (\state -> (state { 
+  transCT (\state -> (state {
                         ptrmap = Map.union (ptrmap state) readPtrMap,
                         objmap = Map.union (objmap state) readObjMap
                       }, ()))
@@ -417,7 +417,7 @@ dumpMaps  = do
 
 incompatibleCallHooksErr            :: Position -> Position -> GB a
 incompatibleCallHooksErr here there  =
-  raiseErrorCTExc here 
+  raiseErrorCTExc here
     ["Incompatible call hooks!",
      "There is a another call hook for the same C function at " ++ show there,
      "The flags and C function name of the two hooks should be identical,",

--- a/tools/c2hs/gen/GenBind.hs
+++ b/tools/c2hs/gen/GenBind.hs
@@ -25,12 +25,12 @@
 --
 --  language: Haskell 98
 --
---  * If there is an error in one binding hook, it is skipped and the next one 
+--  * If there is an error in one binding hook, it is skipped and the next one
 --    is processed (to collect as many errors as possible).  However, if at
 --    least one error occurred, the expansion of binding hooks ends in a fatal
 --    exception.
 --
---  * `CST' exceptions are used to back off a binding hook as soon as an error 
+--  * `CST' exceptions are used to back off a binding hook as soon as an error
 --    is encountered while it is processed.
 --
 --  Mapping of C types to Haskell FFI types:
@@ -78,7 +78,7 @@
 --  Identifier lookup:
 --  ------------------
 --
---  We allow to identify enumerations and structures by the names of `typedef' 
+--  We allow to identify enumerations and structures by the names of `typedef'
 --  types aliased to them.
 --
 --  * enumerations: It is first checked whether there is a tag with the given
@@ -108,8 +108,8 @@
 --    from `evalConstCExpr'.  Haskell 98 FFI standardises `Bits'; use that.
 --
 
-module GenBind (expandHooks) 
-where 
+module GenBind (expandHooks)
+where
 
 -- standard libraries
 import Data.Char          (toUpper, toLower, isSpace)
@@ -151,7 +151,7 @@ import C          (AttrC, CObj(..), CTag(..), lookupDefObjC, lookupDefTagC,
 -- friends
 import CHS        (CHSModule(..), CHSFrag(..), CHSHook(..), CHSTrans(..),
                    CHSParm(..), CHSArg(..), CHSAccess(..), CHSAPath(..),
-                   CHSPtrType(..), showCHSParm) 
+                   CHSPtrType(..), showCHSParm)
 import CInfo      (CPrimType(..), size, alignment, bitfieldIntSigned,
                    bitfieldAlignment)
 import GBMonad    (TransFun, transTabToTransFun, HsObject(..), GB, HsPtrRep,
@@ -162,7 +162,7 @@ import GBMonad    (TransFun, transTabToTransFun, HsObject(..), GB, HsPtrRep,
 -- default marshallers
 -- -------------------
 
--- FIXME: 
+-- FIXME:
 -- - we might have a dynamically extended table in the monad if needed (we
 --   could marshall enums this way and also save the `id' marshallers for
 --   pointers defined via (newtype) pointer hooks)
@@ -171,32 +171,32 @@ import GBMonad    (TransFun, transTabToTransFun, HsObject(..), GB, HsPtrRep,
 -- determine the default "in" marshaller for the given Haskell and C types
 --
 lookupDftMarshIn :: String -> [ExtType] -> GB (Maybe (Ident, CHSArg))
-lookupDftMarshIn "Bool"   [PrimET pt] | isIntegralCPrimType pt = 
+lookupDftMarshIn "Bool"   [PrimET pt] | isIntegralCPrimType pt =
   return $ Just (cFromBoolIde, CHSValArg)
-lookupDftMarshIn hsTy     [PrimET pt] | isIntegralHsType hsTy 
-                                      &&isIntegralCPrimType pt = 
+lookupDftMarshIn hsTy     [PrimET pt] | isIntegralHsType hsTy
+                                      &&isIntegralCPrimType pt =
   return $ Just (cIntConvIde, CHSValArg)
-lookupDftMarshIn hsTy     [PrimET pt] | isFloatHsType hsTy 
-                                      &&isFloatCPrimType pt    = 
+lookupDftMarshIn hsTy     [PrimET pt] | isFloatHsType hsTy
+                                      &&isFloatCPrimType pt    =
   return $ Just (cFloatConvIde, CHSValArg)
 lookupDftMarshIn "String" [PtrET (PrimET CCharPT)]             =
   return $ Just (withCStringIde, CHSIOArg)
-lookupDftMarshIn "String" [PtrET (PrimET CCharPT), PrimET pt]  
+lookupDftMarshIn "String" [PtrET (PrimET CCharPT), PrimET pt]
   | isIntegralCPrimType pt                                     =
   return $ Just (withCStringLenIde, CHSIOArg)
 lookupDftMarshIn hsTy     [PtrET ty]  | showExtType ty == hsTy =
   return $ Just (withIde, CHSIOArg)
-lookupDftMarshIn hsTy     [PtrET (PrimET pt)]  
+lookupDftMarshIn hsTy     [PtrET (PrimET pt)]
   | isIntegralHsType hsTy && isIntegralCPrimType pt            =
   return $ Just (withIntConvIde, CHSIOArg)
-lookupDftMarshIn hsTy     [PtrET (PrimET pt)]  
+lookupDftMarshIn hsTy     [PtrET (PrimET pt)]
   | isFloatHsType hsTy && isFloatCPrimType pt                  =
   return $ Just (withFloatConvIde, CHSIOArg)
-lookupDftMarshIn "Bool"   [PtrET (PrimET pt)]  
+lookupDftMarshIn "Bool"   [PtrET (PrimET pt)]
   | isIntegralCPrimType pt                                     =
   return $ Just (withFromBoolIde, CHSIOArg)
 -- FIXME: handle array-list conversion
-lookupDftMarshIn _        _                                    = 
+lookupDftMarshIn _        _                                    =
   return Nothing
 
 -- determine the default "out" marshaller for the given Haskell and C types
@@ -204,24 +204,24 @@ lookupDftMarshIn _        _                                    =
 lookupDftMarshOut :: String -> [ExtType] -> GB (Maybe (Ident, CHSArg))
 lookupDftMarshOut "()"     _                                    =
   return $ Just (voidIde, CHSVoidArg)
-lookupDftMarshOut "Bool"   [PrimET pt] | isIntegralCPrimType pt = 
+lookupDftMarshOut "Bool"   [PrimET pt] | isIntegralCPrimType pt =
   return $ Just (cToBoolIde, CHSValArg)
-lookupDftMarshOut hsTy     [PrimET pt] | isIntegralHsType hsTy 
-                                       &&isIntegralCPrimType pt = 
+lookupDftMarshOut hsTy     [PrimET pt] | isIntegralHsType hsTy
+                                       &&isIntegralCPrimType pt =
   return $ Just (cIntConvIde, CHSValArg)
-lookupDftMarshOut hsTy     [PrimET pt] | isFloatHsType hsTy 
-                                       &&isFloatCPrimType pt    = 
+lookupDftMarshOut hsTy     [PrimET pt] | isFloatHsType hsTy
+                                       &&isFloatCPrimType pt    =
   return $ Just (cFloatConvIde, CHSValArg)
 lookupDftMarshOut "String" [PtrET (PrimET CCharPT)]             =
   return $ Just (peekCStringIde, CHSIOArg)
-lookupDftMarshOut "String" [PtrET (PrimET CCharPT), PrimET pt]  
+lookupDftMarshOut "String" [PtrET (PrimET CCharPT), PrimET pt]
   | isIntegralCPrimType pt                                      =
   return $ Just (peekCStringLenIde, CHSIOArg)
 lookupDftMarshOut hsTy     [PtrET ty]  | showExtType ty == hsTy =
   return $ Just (peekIde, CHSIOArg)
 -- FIXME: add combination, such as "peek" plus "cIntConv" etc
 -- FIXME: handle array-list conversion
-lookupDftMarshOut _        _                                    = 
+lookupDftMarshOut _        _                                    =
   return Nothing
 
 
@@ -255,7 +255,7 @@ isFloatHsType _        = False
 isIntegralCPrimType :: CPrimType -> Bool
 isIntegralCPrimType  = (`elem` [CCharPT, CSCharPT, CIntPT, CShortPT, CLongPT,
                                 CLLongPT, CUIntPT, CUCharPT, CUShortPT,
-                                CULongPT, CULLongPT]) 
+                                CULongPT, CULLongPT])
 
 -- check for floating C types
 --
@@ -325,11 +325,11 @@ expandModule (CHSModule frags)  =
         warnmsgs <- showErrors
         return (CHSModule (frags' ++ delayedFrags), chi, warnmsgs)
   where
-    traceInfoExpand = putTraceStr tracePhasesSW 
+    traceInfoExpand = putTraceStr tracePhasesSW
                         ("...expanding binding hooks...\n")
-    traceInfoErr    = putTraceStr tracePhasesSW 
+    traceInfoErr    = putTraceStr tracePhasesSW
                         ("...error(s) detected.\n")
-    traceInfoOK     = putTraceStr tracePhasesSW 
+    traceInfoOK     = putTraceStr tracePhasesSW
                         ("...successfully completed.\n")
 
 expandFrags :: [CHSFrag] -> GB [CHSFrag]
@@ -339,16 +339,16 @@ expandFrag :: CHSFrag -> GB [CHSFrag]
 expandFrag verb@(CHSVerb _ _     ) = return [verb]
 expandFrag line@(CHSLine _       ) = return [line]
 expandFrag prag@(CHSLang _ _     ) = return [prag]
-expandFrag      (CHSHook h       ) = 
+expandFrag      (CHSHook h       ) =
   do
     code <- expandHook h
     return [CHSVerb code builtinPos]
   `ifCTExc` return [CHSVerb "** ERROR **" builtinPos]
-expandFrag      (CHSCPP  s _     ) = 
+expandFrag      (CHSCPP  s _     ) =
   interr $ "GenBind.expandFrag: Left over CHSCPP!\n---\n" ++ s ++ "\n---"
-expandFrag      (CHSC    s _     ) = 
+expandFrag      (CHSC    s _     ) =
   interr $ "GenBind.expandFrag: Left over CHSC!\n---\n" ++ s ++ "\n---"
-expandFrag      (CHSCond alts dft) = 
+expandFrag      (CHSCond alts dft) =
   do
     traceInfoCond
     select alts
@@ -369,17 +369,17 @@ expandFrag      (CHSCond alts dft) =
     traceInfoVal ide oobj = traceGenBind $ identToLexeme ide ++ " is " ++
                               (if isNothing oobj then "not " else "") ++
                               "defined.\n"
-    traceInfoDft dft      = if isNothing dft 
-                            then 
-                              return () 
-                            else 
+    traceInfoDft dft      = if isNothing dft
+                            then
+                              return ()
+                            else
                               traceGenBind "Choosing else branch.\n"
 
 expandHook :: CHSHook -> GB String
 expandHook (CHSImport qual ide chi _) =
   do
     mergeMaps chi
-    return $ 
+    return $
       "import " ++ (if qual then "qualified " else "") ++ identToLexeme ide
 expandHook (CHSContext olib oprefix olock _) =
   do
@@ -396,7 +396,7 @@ expandHook (CHSType ide pos) =
   where
     traceInfoType         = traceGenBind "** Type hook:\n"
     traceInfoDump decl ty = traceGenBind $
-      "Declaration\n" ++ show decl ++ "\ntranslates to\n" 
+      "Declaration\n" ++ show decl ++ "\ntranslates to\n"
       ++ showExtType ty ++ "\n"
 expandHook (CHSSizeof ide pos) =
   do
@@ -408,7 +408,7 @@ expandHook (CHSSizeof ide pos) =
   where
     traceInfoSizeof         = traceGenBind "** Sizeof hook:\n"
     traceInfoDump decl size = traceGenBind $
-      "Size of declaration\n" ++ show decl ++ "\nis " 
+      "Size of declaration\n" ++ show decl ++ "\nis "
       ++ show (fromIntegral . padBits $ size) ++ "\n"
 expandHook (CHSEnum cide oalias chsTrans oprefix derive _) =
   do
@@ -427,7 +427,7 @@ expandHook hook@(CHSCall isPure isUns isNol ide oalias pos) =
   do
     traceEnter
     -- get the corresponding C declaration; raises error if not found or not a
-    -- function; we use shadow identifiers, so the returned identifier is used 
+    -- function; we use shadow identifiers, so the returned identifier is used
     -- afterwards instead of the original one
     --
     (ObjCO cdecl, ide) <- findFunObj ide True
@@ -437,13 +437,13 @@ expandHook hook@(CHSCall isPure isUns isNol ide oalias pos) =
         cdecl'    = ide `simplifyDecl` cdecl
     callImport hook isPure isUns mLock ideLexeme hsLexeme cdecl' pos
   where
-    traceEnter = traceGenBind $ 
+    traceEnter = traceGenBind $
       "** Call hook for `" ++ identToLexeme ide ++ "':\n"
 expandHook hook@(CHSFun isPure isUns isNol ide oalias ctxt parms parm pos) =
   do
     traceEnter
     -- get the corresponding C declaration; raises error if not found or not a
-    -- function; we use shadow identifiers, so the returned identifier is used 
+    -- function; we use shadow identifiers, so the returned identifier is used
     -- afterwards instead of the original one
     --
     (ObjCO cdecl, cide) <- findFunObj ide True
@@ -457,7 +457,7 @@ expandHook hook@(CHSFun isPure isUns isNol ide oalias ctxt parms parm pos) =
     callImport callHook isPure isUns mLock (identToLexeme cide) fiLexeme cdecl' pos
     funDef isPure hsLexeme fiLexeme cdecl' ctxt mLock parms parm pos
   where
-    traceEnter = traceGenBind $ 
+    traceEnter = traceGenBind $
       "** Fun hook for `" ++ identToLexeme ide ++ "':\n"
 expandHook (CHSField access path pos) =
   do
@@ -472,9 +472,9 @@ expandHook (CHSField access path pos) =
                            CHSGet -> "Get"
                            CHSSet -> "Set"
     traceInfoField     = traceGenBind $ "** " ++ accessString ++ " hook:\n"
-    traceDepth offsets = traceGenBind $ "Depth of access path: " 
+    traceDepth offsets = traceGenBind $ "Depth of access path: "
                                         ++ show (length offsets) ++ "\n"
-    traceValueType et  = traceGenBind $ 
+    traceValueType et  = traceGenBind $
       "Type of accessed value: " ++ showExtType et ++ "\n"
 expandHook (CHSPointer isStar cName oalias ptrKind isNewtype oRefType pos) =
   do
@@ -490,14 +490,14 @@ expandHook (CHSPointer isStar cName oalias ptrKind isNewtype oRefType pos) =
       Left cdecl -> do                          -- found a typedef declaration
         cNameFull <- case declaredName cdecl of
                        Just ide -> return ide
-                       Nothing  -> interr 
+                       Nothing  -> interr
                                      "GenBind.expandHook: Where is the name?"
-        cNameFull `refersToNewDef` ObjCD (TypeCO cdecl) 
+        cNameFull `refersToNewDef` ObjCD (TypeCO cdecl)
                                    -- assoc needed for chasing
         traceInfoCName "declaration" cNameFull
-        unless (isStar || isPtrDecl cdecl) $ 
+        unless (isStar || isPtrDecl cdecl) $
           ptrExpectedErr (posOf cName)
-        (hsType, isFun) <- 
+        (hsType, isFun) <-
           case oRefType of
             Nothing     -> do
                              cDecl <- chaseDecl cNameFull (not isStar)
@@ -530,10 +530,10 @@ expandHook (CHSPointer isStar cName oalias ptrKind isNewtype oRefType pos) =
     adjustPtr _     _          = interr "GenBind.adjustPtr: Where is the Ptr?"
     --
     traceInfoPointer        = traceGenBind "** Pointer hook:\n"
-    traceInfoCName kind ide = traceGenBind $ 
+    traceInfoCName kind ide = traceGenBind $
       "found C " ++ kind ++ " for `" ++ identToLexeme ide ++ "'\n"
-    traceInfoHsType name ty = traceGenBind $ 
-      "associated with Haskell entity `" ++ name ++ "'\nhaving type " ++ ty 
+    traceInfoHsType name ty = traceGenBind $
+      "associated with Haskell entity `" ++ name ++ "'\nhaving type " ++ ty
       ++ "\n"
 expandHook (CHSClass oclassIde classIde typeIde pos) =
   do
@@ -543,14 +543,14 @@ expandHook (CHSClass oclassIde classIde typeIde pos) =
     Pointer ptrType isNewtype <- queryPointer typeIde
     when (ptrType == CHSStablePtr) $
       illegalStablePtrErr pos
-    classDef pos (identToLexeme classIde) (identToLexeme typeIde) 
+    classDef pos (identToLexeme classIde) (identToLexeme typeIde)
              ptrType isNewtype superClasses
   where
     -- compile a list of all super classes (the direct super class first)
     --
     collectClasses            :: Maybe Ident -> GB [(String, String, HsObject)]
     collectClasses Nothing     = return []
-    collectClasses (Just ide)  = 
+    collectClasses (Just ide)  =
       do
         Class oclassIde typeIde <- queryClass ide
         ptr                     <- queryPointer typeIde
@@ -574,7 +574,7 @@ enumDef cenum@(CEnum _ list _) hident trans userDerive =
     let enumVals = [(trans ide, cexpr) | (ide, cexpr) <-  list']  -- translate
         defHead  = enumHead hident
         defBody  = enumBody (length defHead - 2) enumVals
-        inst     = makeDerives 
+        inst     = makeDerives
                    (if enumAuto then "Enum" : userDerive else userDerive) ++
                    if enumAuto then "\n" else "\n" ++ enumInst hident enumVals
     return $ defHead ++ defBody ++ inst
@@ -582,17 +582,17 @@ enumDef cenum@(CEnum _ list _) hident trans userDerive =
     cpos = posOf cenum
     --
     evalTagVals []                     = return ([], True)
-    evalTagVals ((ide, Nothing ):list) = 
+    evalTagVals ((ide, Nothing ):list) =
       do
         (list', derived) <- evalTagVals list
         return ((ide, Nothing):list', derived)
-    evalTagVals ((ide, Just exp):list) = 
+    evalTagVals ((ide, Just exp):list) =
       do
         (list', derived) <- evalTagVals list
         val <- evalConstCExpr exp
         case val of
-          IntResult val' -> 
-            return ((ide, Just $ CConst (CIntConst val' at1) at2):list', 
+          IntResult val' ->
+            return ((ide, Just $ CConst (CIntConst val' at1) at2):list',
                     False)
           FloatResult _ ->
             illegalConstExprErr (posOf exp) "a float result"
@@ -612,7 +612,7 @@ enumHead ident  = "data " ++ ident ++ " = "
 enumBody                        :: Int -> [(String, Maybe CExpr)] -> String
 enumBody indent []               = ""
 enumBody indent ((ide, _):list)  =
-  ide ++ "\n" ++ replicate indent ' ' 
+  ide ++ "\n" ++ replicate indent ' '
   ++ (if null list then "" else "| " ++ enumBody indent list)
 
 -- Haskell code for an instance declaration for `Enum'
@@ -705,17 +705,17 @@ callImport hook isPure isUns mLock ideLexeme hsLexeme cdecl pos =
       unwords (zipWith wrArg foreignVec [1..])++")"
     wrPattern (Just (_,_,Just con,_)) n = "("++con++" arg"++show n++")"
     wrPattern _                    n = "arg"++show n
-    wrForPtr (Just (_,CHSForeignPtr,_,_)) n 
+    wrForPtr (Just (_,CHSForeignPtr,_,_)) n
         = "withForeignPtr arg"++show n++" $ \\argPtr"++show n++" ->"
     wrForPtr _                          n = ""
     wrArg (Just (_,CHSForeignPtr,_,_)) n = "argPtr"++show n
-    wrArg (Just (_,CHSStablePtr,_,_)) n = 
+    wrArg (Just (_,CHSStablePtr,_,_)) n =
         "(castStablePtrToPtr arg"++show n++")"
     wrArg _ n = "arg"++show n
 
     funStr = case mLock of Nothing -> hsLexeme
                            Just lockFun -> lockFun ++ " $ " ++ hsLexeme
-    traceFunType et = traceGenBind $ 
+    traceFunType et = traceGenBind $
       "Imported function type: " ++ showExtType et ++ "\n"
 
 -- Haskell code for the foreign import declaration needed by a call hook
@@ -743,14 +743,14 @@ funDef :: Bool               -- pure function?
        -> Maybe String       -- type context of the new Haskell function
        -> Maybe String       -- lock function
        -> [CHSParm]          -- parameter marshalling description
-       -> CHSParm            -- result marshalling description 
+       -> CHSParm            -- result marshalling description
        -> Position           -- source location of the hook
        -> GB String          -- Haskell code in text form
 funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
   do
     (parms', parm', isImpure) <- addDftMarshaller pos parms parm cdecl
     traceMarsh parms' parm' isImpure
-    let 
+    let
       sig       = hsLexeme ++ " :: " ++ funTy parms' parm' ++ "\n"
       marshs    = [marshArg i parm | (i, parm) <- zip [1..] parms']
       funArgs   = [funArg   | (funArg, _, _, _, _)   <- marshs, funArg   /= ""]
@@ -762,14 +762,14 @@ funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
                   if isPure && isImpure then "  unsafePerformIO $\n" else ""
       lock      = case mLock of Nothing -> ""
                                 Just lock -> lock ++ " $"
-      call      = if isPure 
+      call      = if isPure
                   then "  let {res = " ++ fiLexeme ++ join callArgs ++ "} in\n"
                   else "  " ++ lock ++ fiLexeme ++ join callArgs ++ " >>= \\res ->\n"
       marshRes  = case parm' of
                     CHSParm _ _ twoCVal (Just (_    , CHSVoidArg)) _ -> ""
-                    CHSParm _ _ twoCVal (Just (omIde, CHSIOArg  )) _ -> 
+                    CHSParm _ _ twoCVal (Just (omIde, CHSIOArg  )) _ ->
                       "  " ++ identToLexeme omIde ++ " res >>= \\res' ->\n"
-                    CHSParm _ _ twoCVal (Just (omIde, CHSValArg )) _ -> 
+                    CHSParm _ _ twoCVal (Just (omIde, CHSValArg )) _ ->
                       "  let {res' = " ++ identToLexeme omIde ++ " res} in\n"
                     CHSParm _ _ _       Nothing                    _ ->
                       interr "GenBind.funDef: marshRes: no default?"
@@ -777,11 +777,11 @@ funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
                     CHSParm _ _ _ (Just (_, CHSVoidArg)) _ ->        retArgs
                     _                                      -> "res'":retArgs
       ret       = "(" ++ concat (intersperse ", " retArgs') ++ ")"
-      funBody   = joinLines marshIns  ++ 
+      funBody   = joinLines marshIns  ++
                   call                ++
-                  joinLines marshOuts ++ 
-                  marshRes            ++ 
-                  "  " ++ 
+                  joinLines marshOuts ++
+                  marshRes            ++
+                  "  " ++
                   (if isImpure || not isPure then "return " else "") ++ ret
     return $ sig ++ funHead ++ funBody
   where
@@ -801,13 +801,13 @@ funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
         argTys = [ty | CHSParm im ty _ _  _ <- parms     , notVoid im]
         resTys = [ty | CHSParm _  ty _ om _ <- parm:parms, notVoid om]
         resTup = let
-                   (lp, rp) = if isPure && length resTys == 1 
-                              then ("", "") 
-                              else ("(", ")") 
+                   (lp, rp) = if isPure && length resTys == 1
+                              then ("", "")
+                              else ("(", ")")
                    io       = if isPure then "" else "IO "
                  in
                  io ++ lp ++ concat (intersperse ", " resTys) ++ rp
-                 
+
       in
       ctxt ++ concat (intersperse " -> " (argTys ++ [resTup]))
       where
@@ -818,22 +818,22 @@ funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
     -- for an argument marshaller, generate all "in" and "out" marshalling
     -- code fragments
     --
-    marshArg i (CHSParm (Just (imIde, imArgKind)) _ twoCVal 
+    marshArg i (CHSParm (Just (imIde, imArgKind)) _ twoCVal
                         (Just (omIde, omArgKind)) _        ) =
       let
         a        = "a" ++ show i
         imStr    = identToLexeme imIde
         imApp    = imStr ++ " " ++ a
         funArg   = if imArgKind == CHSVoidArg then "" else a
-        inBndr   = if twoCVal 
+        inBndr   = if twoCVal
                      then "(" ++ a ++ "'1, " ++ a ++ "'2)"
                      else a ++ "'"
         marshIn  = case imArgKind of
                      CHSVoidArg -> imStr ++ " $ \\" ++ inBndr ++ " -> "
                      CHSIOArg   -> imApp ++ " $ \\" ++ inBndr ++ " -> "
-                     CHSValArg  -> "let {" ++ inBndr ++ " = " ++ 
+                     CHSValArg  -> "let {" ++ inBndr ++ " = " ++
                                    imApp ++ "} in "
-        callArg  = if twoCVal 
+        callArg  = if twoCVal
                      then "" ++ a ++ "'1 " ++ a ++ "'2"
                      else a ++ "'"
         omApp    = identToLexeme omIde ++ " " ++ callArg
@@ -841,27 +841,27 @@ funDef isPure hsLexeme fiLexeme cdecl octxt mLock parms parm pos =
         marshOut = case omArgKind of
                      CHSVoidArg -> ""
                      CHSIOArg   -> omApp ++ ">>= \\" ++ outBndr ++ " -> "
-                     CHSValArg  -> "let {" ++ outBndr ++ " = " ++ 
+                     CHSValArg  -> "let {" ++ outBndr ++ " = " ++
                                    omApp ++ "} in "
         retArg   = if omArgKind == CHSVoidArg then "" else outBndr
       in
       (funArg, marshIn, callArg, marshOut, retArg)
     marshArg _ _ = interr "GenBind.funDef: Missing default?"
     --
-    traceMarsh parms parm isImpure = traceGenBind $ 
+    traceMarsh parms parm isImpure = traceGenBind $
       "Marshalling specification including defaults: \n" ++
       showParms (parms ++ [parm]) "" ++
       "  The marshalling is " ++ if isImpure then "impure.\n" else "pure.\n"
       where
         showParms []           = id
         showParms (parm:parms) =   showString "  "
-                                 . showCHSParm parm 
-                                 . showChar '\n' 
+                                 . showCHSParm parm
+                                 . showChar '\n'
                                  . showParms parms
 
 -- add default marshallers for "in" and "out" marshalling
 --
-addDftMarshaller :: Position -> [CHSParm] -> CHSParm -> CDecl 
+addDftMarshaller :: Position -> [CHSParm] -> CHSParm -> CDecl
                  -> GB ([CHSParm], CHSParm, Bool)
 addDftMarshaller pos parms parm cdecl = do
   (_, fType) <- extractFunType pos cdecl True
@@ -875,9 +875,9 @@ addDftMarshaller pos parms parm cdecl = do
     --
     --  * a default marshaller maybe used for "out" marshalling
     --
-    checkResMarsh (CHSParm (Just _) _  _    _       pos) _   = 
+    checkResMarsh (CHSParm (Just _) _  _    _       pos) _   =
       resMarshIllegalInErr      pos
-    checkResMarsh (CHSParm _        _  True _       pos) _   = 
+    checkResMarsh (CHSParm _        _  True _       pos) _   =
       resMarshIllegalTwoCValErr pos
     checkResMarsh (CHSParm _        ty _    omMarsh pos) cTy = do
       (imMarsh', _       ) <- addDftVoid Nothing
@@ -885,7 +885,7 @@ addDftMarshaller pos parms parm cdecl = do
       return (CHSParm imMarsh' ty False omMarsh' pos, isImpure)
     --
     splitFunTy (FunET UnitET ty ) = splitFunTy ty
-    splitFunTy (FunET ty1    ty2) = let 
+    splitFunTy (FunET ty1    ty2) = let
                                       (resTy, argTys) = splitFunTy ty2
                                     in
                                     (resTy, ty1:argTys)
@@ -905,11 +905,11 @@ addDftMarshaller pos parms parm cdecl = do
       (parms'  , isImpure   ) <- addDft parms cTys
       return (CHSParm imMarsh' hsTy True omMarsh' p : parms',
               isImpure || isImpureIn || isImpureOut)
-    addDft []                                             []               = 
+    addDft []                                             []               =
       return ([], False)
-    addDft ((CHSParm _       _    _     _     pos):parms) []               = 
+    addDft ((CHSParm _       _    _     _     pos):parms) []               =
       marshArgMismatchErr pos "This parameter is in excess of the C arguments."
-    addDft []                                             (_:_)            = 
+    addDft []                                             (_:_)            =
       marshArgMismatchErr pos "Parameter marshallers are missing."
     --
     addDftIn _   imMarsh@(Just (_, kind)) _    _    = return (imMarsh,
@@ -937,11 +937,11 @@ addDftMarshaller pos parms parm cdecl = do
 -- compute from an access path, the declarator finally accessed and the index
 -- path required for the access
 --
---  * each element in the index path specifies dereferencing an address and the 
+--  * each element in the index path specifies dereferencing an address and the
 --   offset to be added to the address before dereferencing
 --
 --  * the returned declaration is already normalised (ie, alias have been
---   expanded) 
+--   expanded)
 --
 --  * it may appear as if `t.m' and `t->m' should have different access paths,
 --   as the latter specifies one more dereferencing; this is certainly true in
@@ -993,12 +993,12 @@ accessPath (CHSDeref path pos) =                        --  *a
   where
     derefOrErr (CDecl specs [declr] at) =
       case declr of
-        (Just (CPtrDeclr [_]       declr at), oinit, oexpr) -> 
+        (Just (CPtrDeclr [_]       declr at), oinit, oexpr) ->
           return $ CDecl specs [(Just declr, oinit, oexpr)] at
-        (Just (CPtrDeclr (_:quals) declr at), oinit, oexpr) -> 
-          return $ 
+        (Just (CPtrDeclr (_:quals) declr at), oinit, oexpr) ->
+          return $
             CDecl specs [(Just (CPtrDeclr quals declr at), oinit, oexpr)] at
-        _                                                   -> 
+        _                                                   ->
           ptrExpectedErr pos
 
 -- replaces a declaration by its alias if any
@@ -1031,7 +1031,7 @@ refStruct su ide =
       unknownFieldErr (posOf su) ide
     --
     -- get sizes of preceding fields and the result type (`pre' are all
-    -- declarators preceding `ide' and the first declarator in `post' defines 
+    -- declarators preceding `ide' and the first declarator in `post' defines
     -- `ide')
     --
     let decl = head post
@@ -1055,7 +1055,7 @@ _                                `declNamed` _   =
 setGet :: Position -> CHSAccess -> [BitSize] -> ExtType -> GB String
 setGet pos access offsets ty =
   do
-    let pre = case access of 
+    let pre = case access of
                 CHSSet -> "(\\ptr val -> do {"
                 CHSGet -> "(\\ptr -> do {"
     body <- setGetBody (reverse offsets)
@@ -1077,7 +1077,7 @@ setGet pos access offsets ty =
                             CHSGet -> "val <- " ++ peekOp offset tyTag
                                       ++ extractBitfield
                             CHSSet -> "org <- " ++ peekOp offset tyTag
-                                      ++ insertBitfield 
+                                      ++ insertBitfield
                                       ++ pokeOp offset tyTag "val'"
             where
               -- we have to be careful here to ensure proper sign extension;
@@ -1085,18 +1085,18 @@ setGet pos access offsets ty =
               --  *not* sufficient; instead, we exploit in the following that
               -- `shiftR' performs sign extension
               --
-              extractBitfield = "; return $ (val `shiftL` (" 
-                                ++ bitsPerField ++ " - " 
+              extractBitfield = "; return $ (val `shiftL` ("
+                                ++ bitsPerField ++ " - "
                                 ++ show (bs + bitOffset) ++ ")) `shiftR` ("
                                 ++ bitsPerField ++ " - " ++ show bs
                                 ++ ")"
               bitsPerField    = show $ size CIntPT * 8
               --
               insertBitfield  = "; let {val' = (org .&. " ++ middleMask
-                                ++ ") .|. (val `shiftL` " 
+                                ++ ") .|. (val `shiftL` "
                                 ++ show bitOffset ++ ")}; "
               middleMask      = "fromIntegral (((maxBound::CUInt) `shiftL` "
-                                ++ show bs ++ ") `rotateL` " 
+                                ++ show bs ++ ") `rotateL` "
                                 ++ show bitOffset ++ ")"
     setGetBody (BitSize offset 0 : offsets) =
       do
@@ -1133,9 +1133,9 @@ pointerDef :: Bool              -- explicit `*' in pointer hook
 pointerDef isStar cNameFull hsName ptrKind isNewtype hsType isFun =
   do
     keepOld <- getSwitch oldFFI
-    let ptrArg  = if keepOld 
+    let ptrArg  = if keepOld
                   then "()"             -- legacy FFI interface
-                  else if isNewtype 
+                  else if isNewtype
                   then hsName           -- abstract type
                   else hsType           -- concrete type
         ptrCon  = case ptrKind of
@@ -1149,7 +1149,7 @@ pointerDef isStar cNameFull hsName ptrKind isNewtype hsType isFun =
                         if isNewtype then Just hsName else Nothing,
                         ptrArg)
     return $
-      if isNewtype 
+      if isNewtype
       then "newtype " ++ hsName ++ " = " ++ hsName ++ " (" ++ ptrType ++ ")"
       else "type "    ++ hsName ++ " = "                   ++ ptrType
 
@@ -1177,19 +1177,19 @@ classDef pos className typeName ptrType isNewtype superClasses =
                           c:cs -> toLower c : cs
       fromMethodName  = "from" ++ typeName
       classDefContext = case superClasses of
-                          []                  -> "" 
+                          []                  -> ""
                           (superName, _, _):_ -> superName ++ " p => "
-      classDef        = 
-        "class " ++ classDefContext ++ className ++ " p where\n" 
+      classDef        =
+        "class " ++ classDefContext ++ className ++ " p where\n"
         ++ "  " ++ toMethodName   ++ " :: p -> " ++ typeName ++ "\n"
         ++ "  " ++ fromMethodName ++ " :: " ++ typeName ++ " -> p\n"
-      instDef         = 
+      instDef         =
         "instance " ++ className ++ " " ++ typeName ++ " where\n"
         ++ "  " ++ toMethodName   ++ " = id\n"
         ++ "  " ++ fromMethodName ++ " = id\n"
     instDefs <- castInstDefs superClasses
     return $ classDef ++ instDefs ++ instDef
-  where 
+  where
     castInstDefs [] = return ""
     castInstDefs ((superName, ptrName, Pointer ptrType' isNewtype'):classes) =
       do
@@ -1205,9 +1205,9 @@ classDef pos className typeName ptrType isNewtype superClasses =
             superConstr     = if isNewtype' then ptrName  ++ " " else ""
             instDef         =
               "instance " ++ superName ++ " " ++ typeName ++ " where\n"
-              ++ "  " ++ toMethodName     ++ " (" ++ typeConstr  ++ "p) = " 
+              ++ "  " ++ toMethodName     ++ " (" ++ typeConstr  ++ "p) = "
                 ++ superConstr ++ "(" ++ castFun ++ " p)\n"
-              ++ "  " ++ fromMethodName   ++ " (" ++ superConstr ++ "p) = " 
+              ++ "  " ++ fromMethodName   ++ " (" ++ superConstr ++ "p) = "
                 ++ typeConstr  ++ "(" ++ castFun ++ " p)\n"
         instDefs <- castInstDefs classes
         return $ instDef ++ instDefs
@@ -1276,13 +1276,13 @@ isFunExtType _            = False
 --
 showExtType                        :: ExtType -> String
 showExtType (FunET UnitET res)      = showExtType res
-showExtType (FunET arg res)         = "(" ++ showExtType arg ++ " -> " 
+showExtType (FunET arg res)         = "(" ++ showExtType arg ++ " -> "
                                       ++ showExtType res ++ ")"
 showExtType (IOET t)                = "(IO " ++ showExtType t ++ ")"
-showExtType (PtrET t)               = let ptrCon = if isFunExtType t 
+showExtType (PtrET t)               = let ptrCon = if isFunExtType t
                                                    then "FunPtr" else "Ptr"
                                       in
-                                      "(" ++ ptrCon ++ " " ++ showExtType t 
+                                      "(" ++ ptrCon ++ " " ++ showExtType t
                                       ++ ")"
 showExtType (DefinedET _ (_,_,_,str)) = str
 showExtType (PrimET CPtrPT)         = "(Ptr ())"
@@ -1313,11 +1313,11 @@ showExtType UnitET                  = "()"
 --   wrapped into an `IO' type
 --
 --  * the caller has to guarantee that the object does indeed refer to a
---   function 
+--   function
 --
 extractFunType                  :: Position -> CDecl -> Bool ->
                                    GB ([Maybe HsPtrRep], ExtType)
-extractFunType pos cdecl isPure  = 
+extractFunType pos cdecl isPure  =
   do
     -- remove all declarators except that of the function we are processing;
     -- then, extract the functions arguments and result type (also check that
@@ -1327,18 +1327,18 @@ extractFunType pos cdecl isPure  =
     let (args, resultDecl, variadic) = funResultAndArgs cdecl
     when variadic $
       variadicErr pos cpos
-    preResultType <- liftM (snd . expandSpecialPtrs) $ 
+    preResultType <- liftM (snd . expandSpecialPtrs) $
                      extractSimpleType pos resultDecl
     --
-    -- we can now add the `IO' monad if this is no pure function 
+    -- we can now add the `IO' monad if this is no pure function
     --
-    let resultType = if isPure 
-                     then      preResultType 
+    let resultType = if isPure
+                     then      preResultType
                      else IOET preResultType
     --
     -- compute function arguments and create a function type (a function
     -- prototype with `void' as its single argument declares a nullary
-    -- function) 
+    -- function)
     --
     (foreignSyn, argTypes) <- liftM (unzip . map expandSpecialPtrs) $
                               mapM (extractSimpleType pos) args
@@ -1350,16 +1350,16 @@ extractFunType pos cdecl isPure  =
     -- provide info on Haskell wrappers around C pointers
     expandSpecialPtrs :: ExtType -> (Maybe HsPtrRep, ExtType)
       -- no special treatment for a simple type synonym
-    expandSpecialPtrs all@(DefinedET cdecl (_, CHSPtr, Nothing, _)) = 
+    expandSpecialPtrs all@(DefinedET cdecl (_, CHSPtr, Nothing, _)) =
         (Nothing, PtrET all)
       -- all other Haskell pointer wrappings require
       -- special calling conventions
-    expandSpecialPtrs all@(DefinedET cdecl hsPtrRep) = 
+    expandSpecialPtrs all@(DefinedET cdecl hsPtrRep) =
         (Just hsPtrRep, PtrET all)
       -- non-pointer arguments are passed normal
     expandSpecialPtrs all = (Nothing, all)
 
--- compute a non-struct/union type from the given declaration 
+-- compute a non-struct/union type from the given declaration
 --
 --  * the declaration may have at most one declarator
 --
@@ -1375,7 +1375,7 @@ extractSimpleType pos cdecl  =
       ExtType et -> return et
       SUType  _  -> illegalStructUnionErr (posOf cdecl) pos
   where
-    traceEnter = traceGenBind $ 
+    traceEnter = traceGenBind $
       "Entering `extractSimpleType'...\n"
 
 -- compute a Haskell type for a type referenced in a C pointer type
@@ -1414,7 +1414,7 @@ extractPtrType cdecl  = do
 --
 extractCompType :: CDecl -> GB CompType
 extractCompType cdecl@(CDecl specs declrs ats)  =
-  if length declrs > 1 
+  if length declrs > 1
   then interr "GenBind.extractCompType: Too many declarators!"
   else case declrs of
     [(Just declr, _, size)] | isPtrDeclr declr -> ptrType declr
@@ -1450,7 +1450,7 @@ extractCompType cdecl@(CDecl specs declrs ats)  =
                 (_, et) <- extractFunType (posOf cdecl) cdecl False
                 returnX et
     --
-    -- handle all types, which are not obviously pointers or functions 
+    -- handle all types, which are not obviously pointers or functions
     --
     aliasOrSpecType :: Maybe CExpr -> GB CompType
     aliasOrSpecType size = do
@@ -1459,7 +1459,7 @@ extractCompType cdecl@(CDecl specs declrs ats)  =
         Nothing   -> specType (posOf cdecl) specs size
         Just ide  -> do                    -- this is a typedef alias
           traceAlias ide
-          oHsRepr <- queryPtr (False, ide) -- check for pointer hook alias     
+          oHsRepr <- queryPtr (False, ide) -- check for pointer hook alias
           case oHsRepr of
             Nothing   -> do                -- skip current alias (only one)
                            cdecl' <- getDeclOf ide
@@ -1472,7 +1472,7 @@ extractCompType cdecl@(CDecl specs declrs ats)  =
     --
     -- compute the result for a pointer alias
     --
-    ptrAlias (isFun, ptrTy, wrapped, tyArg) = 
+    ptrAlias (isFun, ptrTy, wrapped, tyArg) =
       returnX $ DefinedET cdecl (isFun, ptrTy, wrapped, tyArg)
     --
     -- wrap an `ExtType' into a `CompType' and convert parametrised pointers
@@ -1480,18 +1480,18 @@ extractCompType cdecl@(CDecl specs declrs ats)  =
     --
     returnX retval@(PtrET et) = do
                                   keepOld <- getSwitch oldFFI
-                                  if keepOld 
+                                  if keepOld
                                     then return $ ExtType (PrimET CPtrPT)
                                     else return $ ExtType retval
     returnX retval            = return $ ExtType retval
     --
     tracePtrType = traceGenBind $ "extractCompType: explicit pointer type\n"
     traceFunType = traceGenBind $ "extractCompType: explicit function type\n"
-    traceAliasOrSpecType Nothing  = traceGenBind $ 
+    traceAliasOrSpecType Nothing  = traceGenBind $
       "extractCompType: checking for alias\n"
-    traceAliasOrSpecType (Just _) = traceGenBind $ 
+    traceAliasOrSpecType (Just _) = traceGenBind $
       "extractCompType: checking for alias of bitfield\n"
-    traceAlias ide = traceGenBind $ 
+    traceAlias ide = traceGenBind $
       "extractCompType: found an alias called `" ++ identToLexeme ide ++ "'\n"
 
 -- C to Haskell type mapping described in the DOCU section
@@ -1545,13 +1545,13 @@ typeMap  = [([void]                      , UnitET           ),
 --  * may not be called for a specifier that defines a typedef alias
 --
 specType :: Position -> [CDeclSpec] -> Maybe CExpr -> GB CompType
-specType cpos specs osize = 
+specType cpos specs osize =
   let tspecs = [ts | CTypeSpec ts <- specs]
   in case lookupTSpec tspecs typeMap of
     Just et | isUnsupportedType et -> unsupportedTypeSpecErr cpos
             | isNothing osize      -> return $ ExtType et     -- not a bitfield
             | otherwise            -> bitfieldSpec tspecs et osize  -- bitfield
-    Nothing                        -> 
+    Nothing                        ->
       case tspecs of
         [CSUType   cu _] -> return $ SUType cu               -- struct or union
         [CEnumType _  _] -> return $ ExtType (PrimET CIntPT) -- enum
@@ -1570,7 +1570,7 @@ specType cpos specs osize =
     matches :: [CTypeSpec] -> [CTypeSpec] -> Bool
     []           `matches` []     = True
     []           `matches` (_:_)  = False
-    (spec:specs) `matches` specs' 
+    (spec:specs) `matches` specs'
       | any (eqSpec spec) specs'  = specs `matches` deleteBy eqSpec spec specs'
       | otherwise                 = False
     --
@@ -1599,11 +1599,11 @@ specType cpos specs osize =
             let size = fromInteger size'
             case et of
               PrimET CUIntPT                      -> returnCT $ CUFieldPT size
-              PrimET CIntPT 
-                |  [signed]      `matches` tspecs 
+              PrimET CIntPT
+                |  [signed]      `matches` tspecs
                 || [signed, int] `matches` tspecs -> returnCT $ CSFieldPT size
-                |  [int]         `matches` tspecs -> 
-                  returnCT $ if bitfieldIntSigned then CSFieldPT size 
+                |  [int]         `matches` tspecs ->
+                  returnCT $ if bitfieldIntSigned then CSFieldPT size
                                                   else CUFieldPT size
               _                                   -> illegalFieldSizeErr pos
             where
@@ -1630,7 +1630,7 @@ data BitSize = BitSize Int Int
 -- ordering relation compares in terms of required storage units
 --
 instance Ord BitSize where
-  bs1@(BitSize o1 b1) <  bs2@(BitSize o2 b2) = 
+  bs1@(BitSize o1 b1) <  bs2@(BitSize o2 b2) =
     padBits bs1 < padBits bs2 || (o1 == o2 && b1 < b2)
   bs1                 <= bs2                 = bs1 < bs2 || bs1 == bs2
     -- the <= instance is needed for Ord's compare functions, which is used in
@@ -1655,7 +1655,7 @@ padBits (BitSize o _)  = o + size CIntPT
 --
 offsetInStruct                :: [CDecl] -> CDecl -> CStructTag -> GB BitSize
 offsetInStruct []    _    _    = return $ BitSize 0 0
-offsetInStruct decls decl tag  = 
+offsetInStruct decls decl tag  =
   do
     (offset, _) <- sizeAlignOfStruct decls tag
     (_, align)  <- sizeAlignOf decl
@@ -1666,7 +1666,7 @@ offsetInStruct decls decl tag  =
 --
 sizeAlignOfStruct :: [CDecl] -> CStructTag -> GB (BitSize, Int)
 sizeAlignOfStruct []    _           = return (BitSize 0 0, 1)
-sizeAlignOfStruct decls CStructTag  = 
+sizeAlignOfStruct decls CStructTag  =
   do
     (offset, preAlign) <- sizeAlignOfStruct (init decls) CStructTag
     (size, align)      <- sizeAlignOf       (last decls)
@@ -1700,25 +1700,25 @@ sizeAlignOf       :: CDecl -> GB (BitSize, Int)
 --
 sizeAlignOf (CDecl specs [(Just declr, _, size)] ats) | isArrDeclr declr =
   interr $ "sizeAlignOf: calculating size of constant array not supported."
-sizeAlignOf cdecl  = 
+sizeAlignOf cdecl  =
   do
     ct <- extractCompType cdecl
     case ct of
-      ExtType (FunET _ _        ) -> return (bitSize CFunPtrPT, 
+      ExtType (FunET _ _        ) -> return (bitSize CFunPtrPT,
                                              alignment CFunPtrPT)
       ExtType (IOET  _          ) -> interr "GenBind.sizeof: Illegal IO type!"
-      ExtType (PtrET t          ) 
-        | isFunExtType t          -> return (bitSize CFunPtrPT, 
+      ExtType (PtrET t          )
+        | isFunExtType t          -> return (bitSize CFunPtrPT,
                                              alignment CFunPtrPT)
         | otherwise               -> return (bitSize CPtrPT, alignment CPtrPT)
       ExtType (DefinedET _ _    ) -> return (bitSize CPtrPT, alignment CPtrPT)
         -- FIXME: The defined type could be a function pointer!!!
       ExtType (PrimET pt        ) -> return (bitSize pt, alignment pt)
       ExtType UnitET              -> voidFieldErr (posOf cdecl)
-      SUType su                   -> 
+      SUType su                   ->
         do
           let (fields, tag) = structMembers su
-          fields' <- let ide = structName su 
+          fields' <- let ide = structName su
                      in
                      if (not . null $ fields) || isNothing ide
                      then return fields
@@ -1741,7 +1741,7 @@ sizeAlignOf cdecl  =
 --   constraint for a bitfield
 --
 alignOffset :: BitSize -> Int -> BitSize
-alignOffset offset@(BitSize octetOffset bitOffset) align 
+alignOffset offset@(BitSize octetOffset bitOffset) align
   | align > 0 && bitOffset /= 0 =               -- close bitfield first
     alignOffset (BitSize (octetOffset + (bitOffset + 7) `div` 8) 0) align
   | align > 0 && bitOffset == 0 =               -- no bitfields involved
@@ -1811,9 +1811,9 @@ evalConstCExpr (CVar ide at) =
   do
     (cobj, _) <- findValueObj ide False
     case cobj of
-      EnumCO ide (CEnum _ enumrs _) -> liftM IntResult $ 
+      EnumCO ide (CEnum _ enumrs _) -> liftM IntResult $
                                          enumTagValue ide enumrs 0
-      _                             -> 
+      _                             ->
         todo $ "GenBind.evalConstCExpr: variable names not implemented yet " ++
                show (posOf at)
   where
@@ -1823,13 +1823,13 @@ evalConstCExpr (CVar ide at) =
     --
     -- Compute the tag value for `ide' defined in the given enumerator list
     --
-    enumTagValue _   []                     _   = 
+    enumTagValue _   []                     _   =
       interr "GenBind.enumTagValue: enumerator not in declaration"
     enumTagValue ide ((ide', oexpr):enumrs) val =
       do
         val' <- case oexpr of
                   Nothing  -> return val
-                  Just exp -> 
+                  Just exp ->
                     do
                       val' <- evalConstCExpr exp
                       case val' of
@@ -1847,9 +1847,9 @@ evalConstCExpr (CConst c _) =
 evalCConst :: CConst -> GB ConstResult
 evalCConst (CIntConst   i _ ) = return $ IntResult i
 evalCConst (CCharConst  c _ ) = return $ IntResult (toInteger (fromEnum c))
-evalCConst (CFloatConst s _ ) = 
+evalCConst (CFloatConst s _ ) =
   todo "GenBind.evalCConst: Float conversion from literal misses."
-evalCConst (CStrConst   s at) = 
+evalCConst (CStrConst   s at) =
   illegalConstExprErr (posOf at) "a string constant"
 
 usualArithConv :: ConstResult -> ConstResult -> (ConstResult, ConstResult)
@@ -1861,41 +1861,41 @@ toFloat :: ConstResult -> ConstResult
 toFloat x@(FloatResult _) = x
 toFloat   (IntResult   i) = FloatResult . fromIntegral $ i
 
-applyBin :: Position 
-         -> CBinaryOp 
-         -> ConstResult 
-         -> ConstResult 
+applyBin :: Position
+         -> CBinaryOp
+         -> ConstResult
+         -> ConstResult
          -> GB ConstResult
-applyBin cpos CMulOp (IntResult   x) 
+applyBin cpos CMulOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x * y)
-applyBin cpos CMulOp (FloatResult x) 
+applyBin cpos CMulOp (FloatResult x)
                      (FloatResult y) = return $ FloatResult (x * y)
-applyBin cpos CDivOp (IntResult   x) 
+applyBin cpos CDivOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x `div` y)
-applyBin cpos CDivOp (FloatResult x) 
+applyBin cpos CDivOp (FloatResult x)
                      (FloatResult y) = return $ FloatResult (x / y)
-applyBin cpos CRmdOp (IntResult   x) 
+applyBin cpos CRmdOp (IntResult   x)
                      (IntResult   y) = return$ IntResult (x `mod` y)
-applyBin cpos CRmdOp (FloatResult x) 
-                     (FloatResult y) = 
+applyBin cpos CRmdOp (FloatResult x)
+                     (FloatResult y) =
   illegalConstExprErr cpos "a % operator applied to a float"
-applyBin cpos CAddOp (IntResult   x) 
+applyBin cpos CAddOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x + y)
-applyBin cpos CAddOp (FloatResult x) 
+applyBin cpos CAddOp (FloatResult x)
                      (FloatResult y) = return $ FloatResult (x + y)
-applyBin cpos CSubOp (IntResult   x) 
+applyBin cpos CSubOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x - y)
-applyBin cpos CSubOp (FloatResult x) 
+applyBin cpos CSubOp (FloatResult x)
                      (FloatResult y) = return $ FloatResult (x - y)
-applyBin cpos CShlOp (IntResult   x) 
+applyBin cpos CShlOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x * 2^y)
-applyBin cpos CShlOp (FloatResult x) 
-                     (FloatResult y) = 
+applyBin cpos CShlOp (FloatResult x)
+                     (FloatResult y) =
   illegalConstExprErr cpos "a << operator applied to a float"
-applyBin cpos CShrOp (IntResult   x) 
+applyBin cpos CShrOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x `div` 2^y)
-applyBin cpos CShrOp (FloatResult x) 
-                     (FloatResult y) = 
+applyBin cpos CShrOp (FloatResult x)
+                     (FloatResult y) =
   illegalConstExprErr cpos "a >> operator applied to a float"
 applyBin cpos CAndOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .&. y)
@@ -1903,36 +1903,36 @@ applyBin cpos COrOp  (IntResult   x)
                      (IntResult   y) = return $ IntResult (x .|. y)
 applyBin cpos CXorOp (IntResult   x)
                      (IntResult   y) = return $ IntResult (x `xor` y)
-applyBin cpos _      (IntResult   x) 
-                     (IntResult   y) = 
+applyBin cpos _      (IntResult   x)
+                     (IntResult   y) =
   todo "GenBind.applyBin: Not yet implemented operator in constant expression."
-applyBin cpos _      (FloatResult x) 
-                     (FloatResult y) = 
+applyBin cpos _      (FloatResult x)
+                     (FloatResult y) =
   todo "GenBind.applyBin: Not yet implemented operator in constant expression."
-applyBin _    _      _ _             = 
+applyBin _    _      _ _             =
   interr "GenBind.applyBinOp: Illegal combination!"
 
 applyUnary :: Position -> CUnaryOp -> ConstResult -> GB ConstResult
-applyUnary cpos CPreIncOp  _               = 
+applyUnary cpos CPreIncOp  _               =
   illegalConstExprErr cpos "a ++ operator"
-applyUnary cpos CPreDecOp  _               = 
+applyUnary cpos CPreDecOp  _               =
   illegalConstExprErr cpos "a -- operator"
-applyUnary cpos CPostIncOp _               = 
+applyUnary cpos CPostIncOp _               =
   illegalConstExprErr cpos "a ++ operator"
-applyUnary cpos CPostDecOp _               = 
+applyUnary cpos CPostDecOp _               =
   illegalConstExprErr cpos "a -- operator"
-applyUnary cpos CAdrOp     _               = 
+applyUnary cpos CAdrOp     _               =
   illegalConstExprErr cpos "a & operator"
-applyUnary cpos CIndOp     _               = 
+applyUnary cpos CIndOp     _               =
   illegalConstExprErr cpos "a * operator"
 applyUnary cpos CPlusOp    arg             = return arg
 applyUnary cpos CMinOp     (IntResult   x) = return (IntResult (-x))
 applyUnary cpos CMinOp     (FloatResult x) = return (FloatResult (-x))
 applyUnary cpos CCompOp    (IntResult   x) = return (IntResult (complement x))
-applyUnary cpos CNegOp     (IntResult   x) = 
+applyUnary cpos CNegOp     (IntResult   x) =
   let r = toInteger . fromEnum $ (x == 0)
   in return (IntResult r)
-applyUnary cpos CNegOp     (FloatResult _) = 
+applyUnary cpos CNegOp     (FloatResult _) =
   illegalConstExprErr cpos "! applied to a float"
 
 
@@ -1966,15 +1966,15 @@ mapMaybeM_ m (Just a)  = m a >> return ()
 
 unknownFieldErr          :: Position -> Ident -> GB a
 unknownFieldErr cpos ide  =
-  raiseErrorCTExc (posOf ide) 
+  raiseErrorCTExc (posOf ide)
     ["Unknown member name!",
-     "The structure has no member called `" ++ identToLexeme ide 
+     "The structure has no member called `" ++ identToLexeme ide
      ++ "'.  The structure is defined at",
      show cpos ++ "."]
 
 illegalStructUnionErr          :: Position -> Position -> GB a
 illegalStructUnionErr cpos pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Illegal structure or union type!",
      "There is not automatic support for marshaling of structures and",
      "unions; the offending type is declared at "
@@ -1982,7 +1982,7 @@ illegalStructUnionErr cpos pos  =
 
 illegalTypeSpecErr      :: Position -> GB a
 illegalTypeSpecErr cpos  =
-  raiseErrorCTExc cpos 
+  raiseErrorCTExc cpos
     ["Illegal type!",
      "The type specifiers of this declaration do not form a legal ANSI C(89) \
      \type."
@@ -1990,7 +1990,7 @@ illegalTypeSpecErr cpos  =
 
 unsupportedTypeSpecErr      :: Position -> GB a
 unsupportedTypeSpecErr cpos  =
-  raiseErrorCTExc cpos 
+  raiseErrorCTExc cpos
     ["Unsupported type!",
      "The type specifier of this declaration is not supported by your C \
      \compiler."
@@ -1998,7 +1998,7 @@ unsupportedTypeSpecErr cpos  =
 
 variadicErr          :: Position -> Position -> GB a
 variadicErr pos cpos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Variadic function!",
      "Calling variadic functions is not supported by the FFI; the function",
      "is defined at " ++ show cpos ++ "."]
@@ -2016,7 +2016,7 @@ voidFieldErr cpos  =
 
 structExpectedErr     :: Ident -> GB a
 structExpectedErr ide  =
-  raiseErrorCTExc (posOf ide) 
+  raiseErrorCTExc (posOf ide)
     ["Expected a structure or union!",
      "Attempt to access member `" ++ identToLexeme ide ++ "' in something not",
      "a structure or union."]
@@ -2038,32 +2038,32 @@ pointerTypeMismatchErr :: Position -> String -> String -> GB a
 pointerTypeMismatchErr pos className superName =
   raiseErrorCTExc pos
     ["Pointer type mismatch!",
-     "The pointer of the class hook for `" ++ className 
+     "The pointer of the class hook for `" ++ className
      ++ "' is of a different kind",
      "than that of the class hook for `" ++ superName ++ "'; this is illegal",
      "as the latter is defined to be an (indirect) superclass of the former."]
 
 illegalFieldSizeErr      :: Position -> GB a
 illegalFieldSizeErr cpos  =
-  raiseErrorCTExc cpos 
+  raiseErrorCTExc cpos
     ["Illegal field size!",
      "Only signed and unsigned `int' types may have a size annotation."]
 
 derefBitfieldErr      :: Position -> GB a
 derefBitfieldErr pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Illegal dereferencing of a bit field!",
      "Bit fields cannot be dereferenced."]
 
 resMarshIllegalInErr     :: Position -> GB a
 resMarshIllegalInErr pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Malformed result marshalling!",
      "There may not be an \"in\" marshaller for the result."]
 
 resMarshIllegalTwoCValErr     :: Position -> GB a
 resMarshIllegalTwoCValErr pos  =
-  raiseErrorCTExc pos 
+  raiseErrorCTExc pos
     ["Malformed result marshalling!",
      "Two C values (i.e., the `&' symbol) are not allowed for the result."]
 

--- a/tools/c2hs/gen/GenHeader.hs
+++ b/tools/c2hs/gen/GenHeader.hs
@@ -20,7 +20,7 @@
 --- DESCRIPTION ---------------------------------------------------------------
 --
 --  This module implements the generation of a custom header from a binding
---  module. 
+--  module.
 --
 --- DOCU ----------------------------------------------------------------------
 --
@@ -45,7 +45,7 @@
 
 module GenHeader (
   genHeader
-) where 
+) where
 
 -- standard libraries
 import Control.Monad     (when)
@@ -77,7 +77,7 @@ type GH a = CST [Name] a
 --   conditionals are replaced by structured conditionals
 --
 genHeader :: CHSModule -> CST s ([String], CHSModule, String)
-genHeader mod = 
+genHeader mod =
   do
     supply <- getNameSupply
     (header, mod) <- runCST (ghModule mod) (names supply)
@@ -146,14 +146,14 @@ ghModule (CHSModule frags) =
 --
 ghFrags :: [CHSFrag] -> GH (DList String, [CHSFrag], FragElem, [CHSFrag])
 ghFrags []    = return (zeroDL, [], EOF, [])
-ghFrags frags = 
+ghFrags frags =
   do
     (header, frag, rest) <- ghFrag frags
     case frag of
       Frag aFrag -> do
                       (header2, frags', frag', rest) <- ghFrags rest
                       -- FIXME: Not tail rec
-                      return (header `joinDL` header2, aFrag:frags', 
+                      return (header `joinDL` header2, aFrag:frags',
                               frag', rest)
       _          -> return (header, [], frag, rest)
 
@@ -166,7 +166,7 @@ ghFrag :: [CHSFrag] -> GH (DList String, -- partial header file
                            [CHSFrag])    -- not yet processed fragments
 ghFrag []                              =
   return (zeroDL, EOF, [])
-ghFrag (frag@(CHSVerb  _ _  ) : frags) = 
+ghFrag (frag@(CHSVerb  _ _  ) : frags) =
   return (zeroDL, Frag frag, frags)
 ghFrag (frag@(CHSHook  _    ) : frags) =
   return (zeroDL, Frag frag, frags)
@@ -184,7 +184,7 @@ ghFrag (     (CHSCond _  _  ) : frags) =
 ghFrag (frag@(CHSCPP  s  pos) : frags) =
   let
     (directive, _) =   break (`elem` " \t")
-                     . dropWhile (`elem` " \t") 
+                     . dropWhile (`elem` " \t")
                      $ s
   in
   case directive of
@@ -201,7 +201,7 @@ ghFrag (frag@(CHSCPP  s  pos) : frags) =
     --  * Arguments are the lexeme of the directive `s', the position of that
     --   directive `pos', and the fragments following the directive `frags'
     --
-    openIf s pos frags = 
+    openIf s pos frags =
       do
         (headerTh, fragsTh, last, rest) <- ghFrags frags
         case last of
@@ -210,10 +210,10 @@ ghFrag (frag@(CHSCPP  s  pos) : frags) =
                            case last of
                              Else    pos -> notOpenCondErr pos
                              Elif  _ pos -> notOpenCondErr pos
-                             Endif   pos -> closeIf 
-                                              ((headerTh 
+                             Endif   pos -> closeIf
+                                              ((headerTh
                                                 `snocDL` "#else\n")
-                                               `joinDL` 
+                                               `joinDL`
                                                (headerEl
                                                 `snocDL` "#endif\n"))
                                               (s, fragsTh)
@@ -224,18 +224,18 @@ ghFrag (frag@(CHSCPP  s  pos) : frags) =
           Elif s' pos -> do
                            (headerEl, condFrag, rest) <- openIf s' pos rest
                            case condFrag of
-                             Frag (CHSCond alts dft) -> 
+                             Frag (CHSCond alts dft) ->
                                closeIf (headerTh `joinDL` headerEl)
                                        (s, fragsTh)
                                        alts
                                        dft
                                        rest
-                             _                       -> 
+                             _                       ->
                                interr "GenHeader.ghFrag: Expected CHSCond!"
-          Endif   pos -> closeIf (headerTh `snocDL` "#endif\n") 
+          Endif   pos -> closeIf (headerTh `snocDL` "#endif\n")
                                  (s, fragsTh)
                                  []
-                                 (Just []) 
+                                 (Just [])
                                  rest
           EOF         -> notClosedCondErr pos
     --
@@ -245,7 +245,7 @@ ghFrag (frag@(CHSCPP  s  pos) : frags) =
     --   which `fragTh' should be executed; `alts' are alternative branches
     --   (with conditions); and `oelse' is an optional else-branch
     --
-    closeIf headerTail (s, fragsTh) alts oelse rest = 
+    closeIf headerTail (s, fragsTh) alts oelse rest =
       do
         sentryName <- newName
         let sentry = onlyPosIdent nopos sentryName
@@ -253,7 +253,7 @@ ghFrag (frag@(CHSCPP  s  pos) : frags) =
                        -- equality with identifiers read from the .i file
                        -- during binding hook expansion
             header = openDL ['#':s, "\n",
-                             "struct ", sentryName, ";\n"] 
+                             "struct ", sentryName, ";\n"]
                             `joinDL` headerTail
         return (header, Frag (CHSCond ((sentry, fragsTh):alts) oelse), rest)
 

--- a/tools/c2hs/state/C2HSState.hs
+++ b/tools/c2hs/state/C2HSState.hs
@@ -21,7 +21,7 @@
 --
 --  This module instantiates the Compiler Toolkit's extra state with C2HS's
 --  uncommon state information that should be stored in the Toolkit's base
---  state. 
+--  state.
 --
 --  This modules re-exports everything provided by `State', and thus, should be
 --  used as the single reference to state related functionality within C2HS.
@@ -48,14 +48,14 @@ module C2HSState (-- re-exports all of `State'
                   -- switches
                   --
                   SwitchBoard(..), Traces(..), setTraces, traceSet,
-                  putTraceStr, setSwitch, getSwitch) 
+                  putTraceStr, setSwitch, getSwitch)
 where
 
 import Control.Monad    (when)
 
 import State
 
-import Switches (SwitchBoard(..), Traces(..), 
+import Switches (SwitchBoard(..), Traces(..),
                  initialSwitchBoard)
 
 

--- a/tools/c2hs/toplevel/C2HSConfig.hs
+++ b/tools/c2hs/toplevel/C2HSConfig.hs
@@ -24,7 +24,7 @@
 --  Configuration options; largely set by `configure'.
 --
 --- TODO ----------------------------------------------------------------------
---  
+--
 module C2HSConfig (
   --
   -- programs and paths

--- a/tools/c2hs/toplevel/c2hs_config.c
+++ b/tools/c2hs/toplevel/c2hs_config.c
@@ -44,7 +44,7 @@ int bitfield_direction ()
 
   /* if setting the second bit in a bitfield makes the storage unit contain
    * the value `2', the direction of bitfields must be increasing towards the
-   * MSB 
+   * MSB
    */
   v.allbits            = 0;
   v.twobits.second_bit = 1;
@@ -53,7 +53,7 @@ int bitfield_direction ()
 }
 
 
-/* use padding for overspilling bitfields?  
+/* use padding for overspilling bitfields?
  * =======================================
  */
 
@@ -109,7 +109,7 @@ int bitfield_int_signed ()
 }
 
 
-/* alignment constraint for bitfields	    
+/* alignment constraint for bitfields
  * ==================================
  */
 

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, ViewPatterns #-}
+{-# LANGUAGE CPP #-}
 -- | Build a Gtk2hs package.
 module Gtk2HsSetup
   ( gtk2hsUserHooks

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -89,7 +89,7 @@ libraryConfig lbi = case [clbi | (LBI.CLibName _, clbi, _) <- componentsConfigs 
 libraryConfig lbi = case [clbi | (LBI.CLibName, clbi, _) <- LBI.componentsConfigs lbi] of
 #endif
   [clbi] -> Just clbi
-  _ -> Nothing
+  _      -> Nothing
 
 -- the name of the c2hs pre-compiled header file
 precompFile = "precompchs.bin"
@@ -503,7 +503,7 @@ fixDeps pd@PD.PackageDescription {
   }}
 
 data ModDep = ModDep {
-  mdExposed :: Bool,
+  mdExposed  :: Bool,
   mdRequires :: [ModuleName],
   mdOriginal :: ModuleName,
   mdLocation :: Maybe FilePath

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -128,7 +128,7 @@ fixLibs :: [FilePath] -> [String] -> [String]
 fixLibs dlls = concatMap $ \ lib ->
     case filter (isLib lib) dlls of
                 dlls@(_:_) -> [dropExtension (pickDll dlls)]
-                _          -> if lib == "z" then [] else [lib]
+                _          -> [lib | lib /= "z"]
   where
     -- If there are several .dll files matching the one we're after then we
     -- just have to guess. For example for recent Windows cairo builds we get
@@ -231,7 +231,7 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
                            verbosity pkg lib lbi clbi inplace reloc distPref
                            (registrationPackageDB absPackageDBs)
 
-    dllsInScope <- getSearchPath >>= (filterM doesDirectoryExist) >>= getDlls
+    dllsInScope <- getSearchPath >>= filterM doesDirectoryExist >>= getDlls
     let libs = fixLibs dllsInScope (extraLibraries installedPkgInfoRaw)
         installedPkgInfo = installedPkgInfoRaw {
                                 extraGHCiLibraries = libs }
@@ -358,9 +358,9 @@ installCHI pkg@PD.PackageDescription { library = Just lib } lbi verbosity copyde
 #endif
 
 #if MIN_VERSION_Cabal(3,14,0)
-  let files = [ bimap getSymbolicPath getSymbolicPath $ f | Just f <- mFiles ]
+  let files = map (bimap getSymbolicPath getSymbolicPath) $ catMaybes mFiles
 #else
-  let files = [ f | Just f <- mFiles ]
+  let files = catMaybes mFiles
 #endif
   installOrdinaryFiles verbosity libPref files
 
@@ -496,7 +496,7 @@ fixDeps pd@PD.PackageDescription {
                 zipWith (ModDep False []) othMods mOthFiles
 #endif
   modDeps <- mapM extractDeps modDeps
-  let (othMods, expMods) = span (not . mdExposed) $ reverse $ sortTopological modDeps
+  let (othMods, expMods) = break mdExposed $ reverse $ sortTopological modDeps
   return pd { PD.library = Just lib {
     PD.exposedModules = map mdOriginal (reverse expMods),
     PD.libBuildInfo = bi { PD.otherModules = map mdOriginal (reverse othMods) }
@@ -523,7 +523,7 @@ instance Ord ModDep where
 extractDeps :: ModDep -> IO ModDep
 extractDeps md@ModDep { mdLocation = Nothing } = return md
 extractDeps md@ModDep { mdLocation = Just f } = withUTF8FileContents f $ \con -> do
-  let findImports acc (('{':'#':xs):xxs) = case (dropWhile (' ' ==) xs) of
+  let findImports acc (('{':'#':xs):xxs) = case dropWhile (' ' ==) xs of
         ('i':'m':'p':'o':'r':'t':' ':ys) ->
           case simpleParse (takeWhile ('#' /=) ys) of
             Just m -> findImports (m:acc) xxs

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -1,106 +1,75 @@
 {-# LANGUAGE CPP, ViewPatterns #-}
 -- | Build a Gtk2hs package.
---
-module Gtk2HsSetup (
-  gtk2hsUserHooks,
-  getPkgConfigPackages,
-  checkGtk2hsBuildtools,
-  typeGenProgram,
-  signalGenProgram,
-  c2hsLocal
+module Gtk2HsSetup
+  ( gtk2hsUserHooks
+  , getPkgConfigPackages
+  , checkGtk2hsBuildtools
+  , typeGenProgram
+  , signalGenProgram
+  , c2hsLocal
   ) where
 
-import Data.String(fromString)
-import Data.Maybe (mapMaybe)
-import Distribution.Simple
-import Distribution.Simple.PreProcess
-import Distribution.InstalledPackageInfo ( importDirs,
-                                           showInstalledPackageInfo,
-                                           libraryDirs,
-                                           extraLibraries,
-                                           extraGHCiLibraries )
-import Distribution.Simple.PackageIndex ( lookupUnitId )
-import Distribution.PackageDescription as PD ( PackageDescription(..),
-                                               updatePackageDescription,
-                                               BuildInfo(..),
-                                               emptyBuildInfo, allBuildInfo,
-                                               Library(..),
-                                               explicitLibModules, hasLibs)
-import Distribution.Simple.LocalBuildInfo (LocalBuildInfo(..), buildDir,
-                                           InstallDirs(..),
-                                           ComponentLocalBuildInfo,
-                                           componentPackageDeps,
-                                           absoluteInstallDirs,
-                                           relocatable,
-                                           compiler)
-import Distribution.Types.LocalBuildInfo as LBI (componentNameCLBIs)
-import qualified Distribution.Types.LocalBuildInfo as LBI
-import Distribution.Simple.Compiler  ( Compiler(..) )
-import Distribution.Simple.Program (
-  Program(..), ConfiguredProgram(..),
-  runDbProgram, getDbProgramOutput, programName, programPath,
-  c2hsProgram, pkgConfigProgram, gccProgram, requireProgram, ghcPkgProgram,
-  simpleProgram, lookupProgram, getProgramOutput, ProgArg)
-import Distribution.Simple.Program.HcPkg ( defaultRegisterOptions )
-import Distribution.Types.PkgconfigDependency ( PkgconfigDependency(..) )
-import Distribution.Types.PkgconfigName
-import Distribution.ModuleName ( ModuleName, components, toFilePath )
-import Distribution.Simple.Utils hiding (die)
-import Distribution.Simple.BuildPaths ( autogenPackageModulesDir )
-import Distribution.Simple.Install ( install )
-import Distribution.Simple.Register ( generateRegistrationInfo, registerPackage )
-import Distribution.Text ( simpleParse, display )
-import System.FilePath
-import System.Exit (die, exitFailure)
-import System.Directory ( doesFileExist, getDirectoryContents, doesDirectoryExist )
-import Distribution.Version (Version(..))
-import Distribution.Verbosity
-import Control.Monad (when, unless, filterM, liftM, forM, forM_)
-import Data.Maybe ( isJust, isNothing, fromMaybe, maybeToList, catMaybes )
-import Data.List (isPrefixOf, isSuffixOf, nub, minimumBy, stripPrefix, tails )
-import Data.Ord as Ord (comparing)
-import Data.Char (isAlpha, isNumber)
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Distribution.PackageDescription as PD
-import qualified Distribution.Simple.LocalBuildInfo as LBI
-import qualified Distribution.InstalledPackageInfo as IPI
-       (installedUnitId)
-import Distribution.Simple.Compiler (compilerVersion)
-import qualified Distribution.Compat.Graph as Graph
-import Control.Applicative ((<$>))
-import Distribution.Simple.Program.Find ( defaultProgramSearchPath )
-import Gtk2HsC2Hs (c2hsMain)
-import HookGenerator (hookGen)
-import TypeGen (typeGen)
-import UNames (unsafeResetRootNameSupply)
+import           Control.Applicative
+import           Control.Monad
+import           Data.Char                              (isAlpha, isNumber)
+import           Data.List                              (isPrefixOf, isSuffixOf,
+                                                         minimumBy, nub,
+                                                         stripPrefix, tails)
+import qualified Data.Map                               as M
+import           Data.Maybe
+import           Data.Ord                               as Ord
+import qualified Data.Set                               as S
+import           Data.String
+import qualified Distribution.Compat.Graph              as Graph
+import           Distribution.InstalledPackageInfo
+import qualified Distribution.InstalledPackageInfo      as IPI
+import           Distribution.ModuleName                (ModuleName, components,
+                                                         toFilePath)
+import           Distribution.PackageDescription        as PD
+import qualified Distribution.PackageDescription        as PD
+import           Distribution.Simple
+import           Distribution.Simple.BuildPaths         (autogenPackageModulesDir)
+import           Distribution.Simple.Compiler           (Compiler (..),
+                                                         compilerVersion)
+import           Distribution.Simple.Install            (install)
+import           Distribution.Simple.LocalBuildInfo     as LBI
+import           Distribution.Simple.PackageIndex       (lookupUnitId)
+import           Distribution.Simple.PreProcess
+import           Distribution.Simple.Program
+import           Distribution.Simple.Program.Find       (defaultProgramSearchPath)
+import           Distribution.Simple.Program.HcPkg      (defaultRegisterOptions)
+import           Distribution.Simple.Register           (generateRegistrationInfo,
+                                                         registerPackage)
+import           Distribution.Simple.Utils              hiding (die)
+import           Distribution.Text                      (display, simpleParse)
+import qualified Distribution.Types.LocalBuildInfo      as LBI
+import           Distribution.Types.PkgconfigDependency (PkgconfigDependency (..))
+import           Distribution.Types.PkgconfigName
+import           Distribution.Verbosity
+import           Distribution.Version                   (Version (..))
+import           Gtk2HsC2Hs                             (c2hsMain)
+import           HookGenerator                          (hookGen)
+import           System.Directory
+import           System.Exit                            (die, exitFailure)
+import           System.FilePath
+import           TypeGen                                (typeGen)
+import           UNames                                 (unsafeResetRootNameSupply)
+import           Distribution.Simple.Setup
 
 #if MIN_VERSION_Cabal(2,4,0)
-import Distribution.Pretty (prettyShow)
+import           Distribution.Pretty                    (prettyShow)
 #else
-import Distribution.Simple.LocalBuildInfo (getComponentLocalBuildInfo)
+import           Distribution.Simple.LocalBuildInfo     (getComponentLocalBuildInfo)
 #endif
 
 #if MIN_VERSION_Cabal(3,6,0)
-import Distribution.Utils.Path (getSymbolicPath)
+import           Distribution.Utils.Path                (getSymbolicPath)
 #endif
 
 #if MIN_VERSION_Cabal(3,14,0)
-import Data.Bifunctor (bimap)
-import Distribution.Utils.Path (getSymbolicPath, makeRelativePathEx)
-#endif
-
-#if MIN_VERSION_Cabal(3,14,0)
-import Distribution.Simple.Setup (CommonSetupFlags(..), CopyFlags(..), InstallFlags(..),
-                                  CopyDest(..), defaultCommonSetupFlags, defaultCopyFlags,
-                                  ConfigFlags(configVerbosity), fromFlag, toFlag,
-                                  RegisterFlags(..), flagToMaybe, fromFlagOrDefault,
-                                  defaultRegisterFlags)
-#else
-import Distribution.Simple.Setup (CopyFlags(..), InstallFlags(..), CopyDest(..),
-                                  defaultCopyFlags, ConfigFlags(configVerbosity),
-                                  fromFlag, toFlag, RegisterFlags(..), flagToMaybe,
-                                  fromFlagOrDefault, defaultRegisterFlags)
+import           Data.Bifunctor                         (bimap)
+import           Distribution.Utils.Path                (getSymbolicPath,
+                                                         makeRelativePathEx)
 #endif
 
 onDefaultSearchPath f a b = f a b defaultProgramSearchPath

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -149,7 +149,7 @@ fixLibs dlls = concatMap $ \ lib ->
 installHook :: PackageDescription -> LocalBuildInfo
                    -> UserHooks -> InstallFlags -> IO ()
 installHook pkg_descr localbuildinfo _ flags = do
-# if MIN_VERSION_Cabal(3,14,0)
+#if MIN_VERSION_Cabal(3,14,0)
   let copyFlags = defaultCopyFlags {
                         copyCommonFlags = defaultCommonSetupFlags {
                           setupDistPref = installDistPref flags,

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -49,11 +49,9 @@ import Distribution.Simple.Program (
   runDbProgram, getDbProgramOutput, programName, programPath,
   c2hsProgram, pkgConfigProgram, gccProgram, requireProgram, ghcPkgProgram,
   simpleProgram, lookupProgram, getProgramOutput, ProgArg)
-#if MIN_VERSION_Cabal(2,0,0)
 import Distribution.Simple.Program.HcPkg ( defaultRegisterOptions )
 import Distribution.Types.PkgconfigDependency ( PkgconfigDependency(..) )
 import Distribution.Types.PkgconfigName
-#endif
 import Distribution.ModuleName ( ModuleName, components, toFilePath )
 import Distribution.Simple.Utils hiding (die)
 #if MIN_VERSION_Cabal(3,14,0)
@@ -68,9 +66,7 @@ import Distribution.Simple.Setup (CopyFlags(..), InstallFlags(..), CopyDest(..),
                                   fromFlag, toFlag, RegisterFlags(..), flagToMaybe,
                                   fromFlagOrDefault, defaultRegisterFlags)
 #endif
-#if MIN_VERSION_Cabal(2,0,0)
 import Distribution.Simple.BuildPaths ( autogenPackageModulesDir )
-#endif
 import Distribution.Simple.Install ( install )
 #if MIN_VERSION_Cabal(3,14,0)
 import Distribution.Utils.Path (getSymbolicPath, makeRelativePathEx)
@@ -107,11 +103,6 @@ import HookGenerator (hookGen)
 import TypeGen (typeGen)
 import UNames (unsafeResetRootNameSupply)
 
-#if !MIN_VERSION_Cabal(2,0,0)
-versionNumbers :: Version -> [Int]
-versionNumbers = versionBranch
-#endif
-
 onDefaultSearchPath f a b = f a b defaultProgramSearchPath
 #if MIN_VERSION_Cabal(2,5,0)
 componentsConfigs :: LocalBuildInfo -> [(LBI.ComponentName, ComponentLocalBuildInfo, [LBI.ComponentName])]
@@ -138,8 +129,6 @@ gtk2hsUserHooks = simpleUserHooks {
     -- hookedPrograms is only included for backwards compatibility with older Setup.hs.
     hookedPrograms = [typeGenProgram, signalGenProgram, c2hsLocal],
     hookedPreProcessors = [(fromString "chs", ourC2hs)],
-    confHook = \pd cf ->
-      (fmap adjustLocalBuildInfo (confHook simpleUserHooks pd cf)),
     postConf = \args cf pd lbi -> do
       genSynthezisedFiles (fromFlag (configVerbosity cf)) pd lbi
       postConf simpleUserHooks args cf pd lbi,
@@ -292,12 +281,7 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
 #else
            registerPackage verbosity (compiler lbi) (withPrograms lbi)
 #endif
-#if MIN_VERSION_Cabal(2,0,0)
              packageDbs installedPkgInfo defaultRegisterOptions
-#else
-             False packageDbs installedPkgInfo
-#endif
-
   where
     modeGenerateRegFile = isJust (flagToMaybe (regGenPkgConf regFlags))
 #if MIN_VERSION_Cabal(3,14,0)
@@ -332,32 +316,11 @@ register _ _ regFlags = notice verbosity "No package to register"
 #endif
 
 ------------------------------------------------------------------------------
--- This is a hack for Cabal-1.8, It is not needed in Cabal-1.9.1 or later
-------------------------------------------------------------------------------
-
-#if MIN_VERSION_Cabal(2,0,0)
-adjustLocalBuildInfo :: LocalBuildInfo -> LocalBuildInfo
-adjustLocalBuildInfo = id
-#else
-adjustLocalBuildInfo :: LocalBuildInfo -> LocalBuildInfo
-adjustLocalBuildInfo lbi =
-  let extra = (Just libBi, [])
-      libBi = emptyBuildInfo { includeDirs = [ autogenPackageModulesDir lbi
-                                             , buildDir lbi ] }
-   in lbi { localPkgDescr = updatePackageDescription extra (localPkgDescr lbi) }
-#endif
-
-------------------------------------------------------------------------------
 -- Processing .chs files with our local c2hs.
 ------------------------------------------------------------------------------
 
-#if MIN_VERSION_Cabal(2,0,0)
 ourC2hs :: BuildInfo -> LocalBuildInfo -> ComponentLocalBuildInfo -> PreProcessor
 ourC2hs bi lbi _ = PreProcessor {
-#else
-ourC2hs :: BuildInfo -> LocalBuildInfo -> PreProcessor
-ourC2hs bi lbi = PreProcessor {
-#endif
 #if MIN_VERSION_Cabal(3,8,1)
   ppOrdering = \_ _ ms -> return ms,
 #endif
@@ -450,12 +413,8 @@ genSynthezisedFiles verb pd lbi = do
                               tag `isPrefixOf` field,
                               field /= (tag++"file")]
               ++ [ "--tag=" ++ tag
-#if MIN_VERSION_Cabal(2,0,0)
                  | PackageIdentifier name version <- cPkgs
                  , let major:minor:_ = versionNumbers version
-#else
-                 | PackageIdentifier name (Version (major:minor:_) _) <- cPkgs
-#endif
                  , let name' = filter isAlpha (display name)
                  , tag <- name'
                         :[ name' ++ "-" ++ show maj ++ "." ++ show d2
@@ -519,13 +478,8 @@ getPkgConfigPackages verbosity lbi pkg =
     [ do version <- pkgconfig ["--modversion", display pkgname]
          case simpleParse version of
            Nothing -> die "parsing output of pkg-config --modversion failed"
-#if MIN_VERSION_Cabal(2,0,0)
            Just v  -> return (PackageIdentifier (mkPackageName $ unPkgconfigName pkgname) v)
     | PkgconfigDependency pkgname _
-#else
-           Just v  -> return (PackageIdentifier pkgname v)
-    | Dependency pkgname _
-#endif
     <- concatMap pkgconfigDepends (allBuildInfo pkg) ]
   where
     pkgconfig = getDbProgramOutput verbosity
@@ -656,9 +610,5 @@ signalGenProgram = simpleProgram "gtk2hsHookGenerator"
 c2hsLocal :: Program
 c2hsLocal = (simpleProgram "gtk2hsC2hs") {
     programFindVersion = \_ _ -> return . Just $
-#if MIN_VERSION_Cabal(2,0,0)
       mkVersion [0,13,13]
-#else
-      Version [0,13,13] []
-#endif
   }

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -12,14 +12,6 @@ module Gtk2HsSetup (
 
 import Data.String(fromString)
 import Data.Maybe (mapMaybe)
-#if MIN_VERSION_Cabal(3,14,0)
-import Data.Bifunctor (bimap)
-#endif
-#if MIN_VERSION_Cabal(2,4,0)
-import Distribution.Pretty (prettyShow)
-#else
-import Distribution.Simple.LocalBuildInfo (getComponentLocalBuildInfo)
-#endif
 import Distribution.Simple
 import Distribution.Simple.PreProcess
 import Distribution.InstalledPackageInfo ( importDirs,
@@ -54,23 +46,8 @@ import Distribution.Types.PkgconfigDependency ( PkgconfigDependency(..) )
 import Distribution.Types.PkgconfigName
 import Distribution.ModuleName ( ModuleName, components, toFilePath )
 import Distribution.Simple.Utils hiding (die)
-#if MIN_VERSION_Cabal(3,14,0)
-import Distribution.Simple.Setup (CommonSetupFlags(..), CopyFlags(..), InstallFlags(..),
-                                  CopyDest(..), defaultCommonSetupFlags, defaultCopyFlags,
-                                  ConfigFlags(configVerbosity), fromFlag, toFlag,
-                                  RegisterFlags(..), flagToMaybe, fromFlagOrDefault,
-                                  defaultRegisterFlags)
-#else
-import Distribution.Simple.Setup (CopyFlags(..), InstallFlags(..), CopyDest(..),
-                                  defaultCopyFlags, ConfigFlags(configVerbosity),
-                                  fromFlag, toFlag, RegisterFlags(..), flagToMaybe,
-                                  fromFlagOrDefault, defaultRegisterFlags)
-#endif
 import Distribution.Simple.BuildPaths ( autogenPackageModulesDir )
 import Distribution.Simple.Install ( install )
-#if MIN_VERSION_Cabal(3,14,0)
-import Distribution.Utils.Path (getSymbolicPath, makeRelativePathEx)
-#endif
 import Distribution.Simple.Register ( generateRegistrationInfo, registerPackage )
 import Distribution.Text ( simpleParse, display )
 import System.FilePath
@@ -91,17 +68,40 @@ import qualified Distribution.InstalledPackageInfo as IPI
        (installedUnitId)
 import Distribution.Simple.Compiler (compilerVersion)
 import qualified Distribution.Compat.Graph as Graph
-#if MIN_VERSION_Cabal(3,6,0)
-import Distribution.Utils.Path (getSymbolicPath)
-#endif
-
 import Control.Applicative ((<$>))
-
 import Distribution.Simple.Program.Find ( defaultProgramSearchPath )
 import Gtk2HsC2Hs (c2hsMain)
 import HookGenerator (hookGen)
 import TypeGen (typeGen)
 import UNames (unsafeResetRootNameSupply)
+
+#if MIN_VERSION_Cabal(2,4,0)
+import Distribution.Pretty (prettyShow)
+#else
+import Distribution.Simple.LocalBuildInfo (getComponentLocalBuildInfo)
+#endif
+
+#if MIN_VERSION_Cabal(3,6,0)
+import Distribution.Utils.Path (getSymbolicPath)
+#endif
+
+#if MIN_VERSION_Cabal(3,14,0)
+import Data.Bifunctor (bimap)
+import Distribution.Utils.Path (getSymbolicPath, makeRelativePathEx)
+#endif
+
+#if MIN_VERSION_Cabal(3,14,0)
+import Distribution.Simple.Setup (CommonSetupFlags(..), CopyFlags(..), InstallFlags(..),
+                                  CopyDest(..), defaultCommonSetupFlags, defaultCopyFlags,
+                                  ConfigFlags(configVerbosity), fromFlag, toFlag,
+                                  RegisterFlags(..), flagToMaybe, fromFlagOrDefault,
+                                  defaultRegisterFlags)
+#else
+import Distribution.Simple.Setup (CopyFlags(..), InstallFlags(..), CopyDest(..),
+                                  defaultCopyFlags, ConfigFlags(configVerbosity),
+                                  fromFlag, toFlag, RegisterFlags(..), flagToMaybe,
+                                  fromFlagOrDefault, defaultRegisterFlags)
+#endif
 
 onDefaultSearchPath f a b = f a b defaultProgramSearchPath
 #if MIN_VERSION_Cabal(2,5,0)

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -57,10 +57,10 @@ import Distribution.Types.PkgconfigName
 import Distribution.ModuleName ( ModuleName, components, toFilePath )
 import Distribution.Simple.Utils hiding (die)
 #if MIN_VERSION_Cabal(3,14,0)
-import Distribution.Simple.Setup (CommonSetupFlags(..), CopyFlags(..), InstallFlags(..), 
-                                  CopyDest(..), defaultCommonSetupFlags, defaultCopyFlags, 
-                                  ConfigFlags(configVerbosity), fromFlag, toFlag, 
-                                  RegisterFlags(..), flagToMaybe, fromFlagOrDefault, 
+import Distribution.Simple.Setup (CommonSetupFlags(..), CopyFlags(..), InstallFlags(..),
+                                  CopyDest(..), defaultCommonSetupFlags, defaultCopyFlags,
+                                  ConfigFlags(configVerbosity), fromFlag, toFlag,
+                                  RegisterFlags(..), flagToMaybe, fromFlagOrDefault,
                                   defaultRegisterFlags)
 #else
 import Distribution.Simple.Setup (CopyFlags(..), InstallFlags(..), CopyDest(..),
@@ -97,7 +97,7 @@ import Distribution.Simple.Compiler (compilerVersion)
 import qualified Distribution.Compat.Graph as Graph
 #if MIN_VERSION_Cabal(3,6,0)
 import Distribution.Utils.Path (getSymbolicPath)
-#endif 
+#endif
 
 import Control.Applicative ((<$>))
 
@@ -192,12 +192,12 @@ installHook :: PackageDescription -> LocalBuildInfo
                    -> UserHooks -> InstallFlags -> IO ()
 installHook pkg_descr localbuildinfo _ flags = do
 # if MIN_VERSION_Cabal(3,14,0)
-  let copyFlags = defaultCopyFlags { 
+  let copyFlags = defaultCopyFlags {
                         copyCommonFlags = defaultCommonSetupFlags {
                           setupDistPref = installDistPref flags,
                           setupVerbosity = installVerbosity flags
                         },
-                        copyDest = toFlag NoCopyDest 
+                        copyDest = toFlag NoCopyDest
                    }
 #else
   let copyFlags = defaultCopyFlags {
@@ -547,12 +547,12 @@ fixDeps pd@PD.PackageDescription {
               PD.hsSourceDirs = srcDirs,
               PD.otherModules = othMods
             }}} = do
-  let toPath = 
+  let toPath =
 #if MIN_VERSION_Cabal(3,6,0)
         getSymbolicPath
-#else 
-        id 
-#endif 
+#else
+        id
+#endif
 #if MIN_VERSION_Cabal(3,14,0)
   let findModule m = findFileWithExtension [fromString ".chs.pp", fromString ".chs"] srcDirs
                        (makeRelativePathEx . toFilePath $ m)
@@ -565,7 +565,7 @@ fixDeps pd@PD.PackageDescription {
 
   -- tag all exposed files with True so we throw an error if we need to build
   -- an exposed module before an internal modules (we cannot express this)
-#if MIN_VERSION_Cabal(3,14,0)  
+#if MIN_VERSION_Cabal(3,14,0)
   let modDeps = zipWith (ModDep True []) expMods (map (getSymbolicPath <$>) mExpFiles) ++
                 zipWith (ModDep False []) othMods (map (getSymbolicPath <$>) mOthFiles)
 #else

--- a/tools/src/Gtk2HsSetup.hs
+++ b/tools/src/Gtk2HsSetup.hs
@@ -215,18 +215,18 @@ installHook pkg_descr localbuildinfo _ flags = do
 #endif
   when (hasLibs pkg_descr) $ register pkg_descr localbuildinfo registerFlags
 
-registerHook :: PackageDescription -> LocalBuildInfo
-        -> UserHooks -> RegisterFlags -> IO ()
+registerHook :: PackageDescription -> LocalBuildInfo -> UserHooks -> RegisterFlags -> IO ()
 registerHook pkg_descr localbuildinfo _ flags =
-    if hasLibs pkg_descr
-    then register pkg_descr localbuildinfo flags
-    else setupMessage verbosity
-           "Package contains no library to register:" (packageId pkg_descr)
+  if hasLibs pkg_descr
+  then register pkg_descr localbuildinfo flags
+  else setupMessage verbosity "Package contains no library to register:" (packageId pkg_descr)
+  where
 #if MIN_VERSION_Cabal(3,14,0)
-  where verbosity = fromFlag (setupVerbosity . registerCommonFlags $ flags)
+    verbosity = fromFlag (setupVerbosity . registerCommonFlags $ flags)
 #else
-  where verbosity = fromFlag (regVerbosity flags)
+    verbosity = fromFlag (regVerbosity flags)
 #endif
+
 #if MIN_VERSION_Cabal(2,4,0)
 getComponentLocalBuildInfo :: LocalBuildInfo -> LBI.ComponentName -> ComponentLocalBuildInfo
 getComponentLocalBuildInfo lbi cname =


### PR DESCRIPTION
My environment build is failed,
So I fixed.

- **build: bump internal `gtk2hs-buildtools`**
- style: format code that remove trailing whitespace and parser friendly
- refactor: drop Cabal <= 2.0.0 code, because this require min cabal 2.0.0
- refactor: remove deprecated function call
- refactor: import statment to grouped
- rafactor: apply hlint